### PR TITLE
feat(auth,frontend): integrate login API and SignIn UI

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,6 +1,8 @@
-import { Body, Controller, HttpCode, HttpStatus, Post } from '@nestjs/common';
+import { Body, Controller, HttpCode, HttpStatus, Post, Res } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { RegisterDto } from './dto/register.dto';
+import { LoginDto } from './dto/login.dto';
+import express from 'express';
 
 @Controller('auth')
 export class AuthController {
@@ -10,5 +12,11 @@ export class AuthController {
     @HttpCode(HttpStatus.OK)
     register(@Body() body: RegisterDto) {
         return this.authService.register(body.name, body.email, body.password, body.confirmPassword);
+    }
+
+    @Post('login')
+    @HttpCode(HttpStatus.OK)
+    login(@Body() body: LoginDto, @Res({ passthrough: true }) res: express.Response) {
+        return this.authService.login(body.email, body.password, res);
     }
 }

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -2,9 +2,21 @@ import { Module } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { AuthController } from './auth.controller';
 import { UsersModule } from 'src/users/users.module';
+import { JwtModule } from '@nestjs/jwt';
+import { ConfigModule, ConfigService } from '@nestjs/config';
 
 @Module({
-  imports: [UsersModule],
+  imports: [
+    UsersModule,
+    JwtModule.registerAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: (configService: ConfigService) => ({
+        secret: configService.get<string>('JWT_SECRET'),
+        signOptions: { expiresIn: '7d' },
+      }),
+    }),
+  ],
   providers: [AuthService],
   controllers: [AuthController]
 })

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -1,10 +1,15 @@
-import { ConflictException, Injectable, InternalServerErrorException } from '@nestjs/common';
+import { ConflictException, Injectable, InternalServerErrorException, UnauthorizedException } from '@nestjs/common';
 import { UsersService } from '../users/users.service';
 import * as bcryptjs from 'bcryptjs';
+import { JwtService } from '@nestjs/jwt';
+import { Response } from 'express';
 
 @Injectable()
 export class AuthService {
-    constructor(private readonly usersService: UsersService) { }
+    constructor(
+        private readonly usersService: UsersService,
+        private readonly jwtService: JwtService
+    ) { }
     
     async register(name: string, email: string, password: string, confirmPassword: string) {
         try {
@@ -23,6 +28,46 @@ export class AuthService {
             return { success: true, message: 'Registro exitoso.' };
         } catch (error) {
             if (error instanceof ConflictException) throw error;
+            const message = error instanceof Error ? error.message : 'Error interno del servidor';
+            throw new InternalServerErrorException(message);
+        }
+    }
+
+    async login(email: string, password: string, res: Response) {
+        try {
+            const user = await this.usersService.findByEmail(email);
+            if (!user) {
+                throw new UnauthorizedException('Credenciales inválidas.');
+            }
+
+            const isMatch = await bcryptjs.compare(password, user.password);
+            if (!isMatch) {
+                throw new UnauthorizedException('Credenciales inválidas.');
+            }
+
+            const payload = {
+                _id: user._id,
+                name: user.name,
+                email: user.email,
+                avatar: user.avatar,
+            };
+
+            const token = this.jwtService.sign(payload);
+
+            const isProduction = process.env.NODE_ENV === 'production';
+
+            res.cookie('access_token', token, {
+                httpOnly: true,
+                secure: isProduction,
+                sameSite: isProduction ? 'none' : 'strict',
+                path: '/',
+            });
+
+            const { password: _, ...safeUser } = user.toObject({ getters: true });
+
+            return { success: true, user: safeUser, message: 'Inicio de sesión correcto.' };
+        } catch (error) {
+            if (error instanceof UnauthorizedException) throw error;
             const message = error instanceof Error ? error.message : 'Error interno del servidor';
             throw new InternalServerErrorException(message);
         }

--- a/backend/src/auth/dto/login.dto.ts
+++ b/backend/src/auth/dto/login.dto.ts
@@ -1,0 +1,10 @@
+import { IsEmail, IsString, MinLength } from 'class-validator';
+
+export class LoginDto {
+    @IsEmail({}, { message: 'El correo electrónico no es válido.' })
+    email!: string;
+
+    @IsString({ message: 'La contraseña debe ser un texto.' })
+    @MinLength(8, { message: 'La contraseña debe tener al menos 8 caracteres.' })
+    password!: string;
+}

--- a/frontend/src/pages/SignIn.jsx
+++ b/frontend/src/pages/SignIn.jsx
@@ -5,14 +5,18 @@ import { Input } from '@/components/ui/input'
 import { zodResolver } from '@hookform/resolvers/zod'
 import z from 'zod'
 import { Card } from '@/components/ui/card'
-import { Link } from 'react-router-dom'
-import { RouteSignUp } from '@/helpers/RouteName'
+import { Link, useNavigate } from 'react-router-dom'
+import { RouteIndex, RouteSignUp } from '@/helpers/RouteName'
+import { showToast } from '@/helpers/showToast'
+import { getEnv } from '@/helpers/getEnv'
 
 const SignIn = () => {
 
+    const navigate = useNavigate()
+
     const formSchema = z.object({
         email: z.string().email(),
-        password: z.string().min(8, 'La contraseña debe ser de al menos 8 caracteres.')
+        password: z.string().min(8, 'Se requiere la contraseña obligatoriamente.')
     })
 
     const form = useForm({
@@ -23,8 +27,24 @@ const SignIn = () => {
         }
     })
 
-    function onSubmit(values) {
-        console.log(values)
+    async function onSubmit(values) {
+        try {
+            const response = await fetch(`${getEnv('VITE_BASE_API_URL')}/auth/login`, {
+                method: 'post',
+                headers: { 'Content-type': 'application/json' },
+                credentials: 'include',
+                body: JSON.stringify(values)
+            })
+            const data = await response.json()
+            if (!response.ok) {
+                showToast('error', data.message)
+                return
+            }
+            showToast('success', data.message)
+            navigate(RouteIndex)
+        } catch (error) {
+            showToast('error', error.message)
+        }
     }
 
     return (


### PR DESCRIPTION
Hook frontend SignIn to backend POST /auth/login (with credentials: 'include'); validate input with LoginDto, authenticate in AuthService, sign JWT and set access_token cookie. Adds client-side success/error toasts and redirect on success.

Modified: auth.controller.ts, auth.service.ts, login.dto.ts, SignIn.jsx