### PR TITLE
feat(frontend): persist login state with zustand; integrate TanStack …

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "@fontsource-variable/inter": "^5.2.8",
         "@hookform/resolvers": "^5.2.2",
         "@tailwindcss/vite": "^4.2.2",
+        "@tanstack/react-query": "^5.100.5",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "firebase": "^12.12.1",
@@ -26,7 +27,8 @@
         "tailwind-merge": "^3.5.0",
         "tailwindcss": "^4.2.2",
         "tw-animate-css": "^1.4.0",
-        "zod": "^4.3.6"
+        "zod": "^4.3.6",
+        "zustand": "^5.0.12"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
@@ -4000,6 +4002,32 @@
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
       }
     },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.100.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.5.tgz",
+      "integrity": "sha512-t20KrhKkf0HXzqQkPbJ5erhFesup68BAbwFgYmTrS7bxMF7O5MdmL8jUkik4thsG7Hg00fblz30h6yF1d5TxGg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.100.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.100.5.tgz",
+      "integrity": "sha512-aNwj1mi2v2bQ9IxkyR1grLOUkv3BYWoykHy9KDyLNbjC3tsahbOHJibK+Wjtr1wRhG59/AvJhiJG5OlthaCgJA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.100.5"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
     "node_modules/@ts-morph/common": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.27.0.tgz",
@@ -4076,7 +4104,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.19.0"
       }
@@ -9172,6 +9199,35 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.12.tgz",
+      "integrity": "sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "@fontsource-variable/inter": "^5.2.8",
     "@hookform/resolvers": "^5.2.2",
     "@tailwindcss/vite": "^4.2.2",
+    "@tanstack/react-query": "^5.100.5",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "firebase": "^12.12.1",
@@ -28,7 +29,8 @@
     "tailwind-merge": "^3.5.0",
     "tailwindcss": "^4.2.2",
     "tw-animate-css": "^1.4.0",
-    "zod": "^4.3.6"
+    "zod": "^4.3.6",
+    "zustand": "^5.0.12"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/frontend/src/components/GoogleLogin.jsx
+++ b/frontend/src/components/GoogleLogin.jsx
@@ -7,41 +7,50 @@ import { RouteIndex } from '@/helpers/RouteName'
 import { getEnv } from '@/helpers/getEnv'
 import { showToast } from '@/helpers/showToast'
 import { useNavigate } from 'react-router-dom'
+import { useMutation } from '@tanstack/react-query'
+import { useUserStore } from '@/store/useUserStore'
 
 const GoogleLogin = () => {
-
     const navigate = useNavigate()
+    const setUser = useUserStore((state) => state.setUser)
 
-    const handleLogin = async () => {
-        try {
+    const googleMutation = useMutation({
+        mutationFn: async () => {
             const googleResponse = await signInWithPopup(auth, provider)
             const user = googleResponse.user
-            const bodyData = {
-                name: user.displayName,
-                email: user.email,
-                avatar: user.photoURL
-            }
             const response = await fetch(`${getEnv('VITE_BASE_API_URL')}/auth/google-login`, {
-                method: 'post',
-                headers: { 'Content-type': 'application/json' },
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
                 credentials: 'include',
-                body: JSON.stringify(bodyData)
+                body: JSON.stringify({
+                    name: user.displayName,
+                    email: user.email,
+                    avatar: user.photoURL,
+                }),
             })
             const data = await response.json()
-            if (!response.ok) {
-                return showToast('error', data.message)
-            }
+            if (!response.ok) throw new Error(data.message)
+            return data
+        },
+        onSuccess: (data) => {
+            setUser(data.user)
             showToast('success', data.message)
             navigate(RouteIndex)
-        } catch (error) {
+        },
+        onError: (error) => {
             showToast('error', error.message)
-        }
-    }
+        },
+    })
 
     return (
-        <Button variant='outline' className='w-full' onClick={handleLogin}>
+        <Button
+            variant='outline'
+            className='w-full'
+            onClick={() => googleMutation.mutate()}
+            disabled={googleMutation.isPending}
+        >
             <FcGoogle />
-            Continuar con Google
+            {googleMutation.isPending ? 'Conectando...' : 'Continuar con Google'}
         </Button>
     )
 }

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -3,10 +3,15 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.jsx'
 import { ToastContainer } from 'react-toastify'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+const queryClient = new QueryClient()
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <ToastContainer />
-    <App />
+    <QueryClientProvider client={queryClient}>
+      <ToastContainer />
+      <App />
+    </QueryClientProvider>
   </StrictMode>
 )

--- a/frontend/src/pages/SignIn.jsx
+++ b/frontend/src/pages/SignIn.jsx
@@ -9,72 +9,76 @@ import { Link, useNavigate } from 'react-router-dom'
 import { RouteIndex, RouteSignUp } from '@/helpers/RouteName'
 import { showToast } from '@/helpers/showToast'
 import { getEnv } from '@/helpers/getEnv'
+import { useMutation } from '@tanstack/react-query'
+import { useUserStore } from '@/store/useUserStore'
+import GoogleLogin from '@/components/GoogleLogin'
+
+const formSchema = z.object({
+    email: z.string().email(),
+    password: z.string().min(8, 'Se requiere la contraseña obligatoriamente.'),
+})
 
 const SignIn = () => {
-
     const navigate = useNavigate()
-
-    const formSchema = z.object({
-        email: z.string().email(),
-        password: z.string().min(8, 'Se requiere la contraseña obligatoriamente.')
-    })
+    const setUser = useUserStore((state) => state.setUser)
 
     const form = useForm({
         resolver: zodResolver(formSchema),
-        defaultValues: {
-            email: '',
-            password: '',
-        }
+        defaultValues: { email: '', password: '' },
     })
 
-    async function onSubmit(values) {
-        try {
+    const loginMutation = useMutation({
+        mutationFn: async (values) => {
             const response = await fetch(`${getEnv('VITE_BASE_API_URL')}/auth/login`, {
-                method: 'post',
-                headers: { 'Content-type': 'application/json' },
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
                 credentials: 'include',
-                body: JSON.stringify(values)
+                body: JSON.stringify(values),
             })
             const data = await response.json()
-            if (!response.ok) {
-                return showToast('error', data.message)
-            }
+            if (!response.ok) throw new Error(data.message)
+            return data
+        },
+        onSuccess: (data) => {
+            setUser(data.user)
             showToast('success', data.message)
             navigate(RouteIndex)
-        } catch (error) {
+        },
+        onError: (error) => {
             showToast('error', error.message)
-        }
-    }
+        },
+    })
 
     return (
         <div className='flex justify-center items-center h-screen w-screen'>
             <Card className='w-100 p-4'>
                 <h1 className='text-2xl font-bold text-center mb-5'>Iniciar Sesión</h1>
+                <div>
+                    <GoogleLogin />
+                    <div className='border my-5 flex justify-center items-center'>
+                        <span className='absolute bg-white'>O</span>
+                    </div>
+                </div>
                 <FormProvider {...form}>
-                    <form onSubmit={form.handleSubmit(onSubmit)} className="w-full max-w-sm space-y-4">
+                    <form onSubmit={form.handleSubmit((values) => loginMutation.mutate(values))} className="w-full max-w-sm space-y-4">
                         <div className='flex flex-col gap-2'>
                             <label className="text-sm font-medium">Email</label>
-                            <Input
-                                {...form.register("email")}
-                                placeholder="Ingrese su correo electrónico"
-                            />
+                            <Input {...form.register("email")} placeholder="Ingrese su correo electrónico" />
                             {form.formState.errors.email && (
                                 <p className="text-sm text-red-500">{form.formState.errors.email.message}</p>
                             )}
                         </div>
                         <div className='flex flex-col gap-2'>
                             <label className="text-sm font-medium">Contraseña</label>
-                            <Input
-                                type="password"
-                                {...form.register("password")}
-                                placeholder="Ingrese su contraseña"
-                            />
+                            <Input type="password" {...form.register("password")} placeholder="Ingrese su contraseña" />
                             {form.formState.errors.password && (
                                 <p className="text-sm text-red-500">{form.formState.errors.password.message}</p>
                             )}
                         </div>
                         <div className='mt-5'>
-                            <Button type="submit" className='w-full'>Ingresar</Button>
+                            <Button type="submit" className='w-full' disabled={loginMutation.isPending}>
+                                {loginMutation.isPending ? 'Ingresando...' : 'Ingresar'}
+                            </Button>
                             <div className='mt-3 text-sm flex justify-center items-center gap-2'>
                                 <p>¿No tienes una cuenta?</p>
                                 <Link className='text-blue-500 hover:underline' to={RouteSignUp}>Registrate aquí</Link>

--- a/frontend/src/pages/SignUp.jsx
+++ b/frontend/src/pages/SignUp.jsx
@@ -10,48 +10,45 @@ import { RouteSignIn } from '@/helpers/RouteName'
 import { getEnv } from '@/helpers/getEnv'
 import { showToast } from '@/helpers/showToast'
 import GoogleLogin from '@/components/GoogleLogin'
+import { useMutation } from '@tanstack/react-query'
+
+const formSchema = z.object({
+    name: z.string().min(3, 'El nombre debe ser de al menos 3 caracteres.'),
+    email: z.string().email(),
+    password: z.string().min(8, 'La contraseña debe ser de al menos 8 caracteres.'),
+    confirmPassword: z.string().min(8, 'La confirmación debe tener al menos 8 caracteres.'),
+}).refine((data) => data.password === data.confirmPassword, {
+    message: 'Las contraseñas no coinciden.',
+    path: ['confirmPassword'],
+})
 
 const SignUp = () => {
-
     const navigate = useNavigate()
-
-    const formSchema = z.object({
-        name: z.string().min(3, 'El nombre debe ser de al menos 3 caracteres.'),
-        email: z.string().email(),
-        password: z.string().min(8, 'La contraseña debe ser de al menos 8 caracteres.'),
-        confirmPassword: z.string().min(8, 'La confirmación debe tener al menos 8 caracteres.')
-    }).refine((data) => data.password === data.confirmPassword, {
-        message: 'Las contraseñas no coinciden.',
-        path: ['confirmPassword'],
-    })
 
     const form = useForm({
         resolver: zodResolver(formSchema),
-        defaultValues: {
-            name: '',
-            email: '',
-            password: '',
-            confirmPassword: '',
-        }
+        defaultValues: { name: '', email: '', password: '', confirmPassword: '' },
     })
 
-    async function onSubmit(values) {
-        try {
+    const registerMutation = useMutation({
+        mutationFn: async (values) => {
             const response = await fetch(`${getEnv('VITE_BASE_API_URL')}/auth/register`, {
-                method: 'post',
-                headers: { 'Content-type': 'application/json' },
-                body: JSON.stringify(values)
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(values),
             })
             const data = await response.json()
-            if (!response.ok) {
-                return showToast('error', data.message)
-            }
+            if (!response.ok) throw new Error(data.message)
+            return data
+        },
+        onSuccess: (data) => {
             showToast('success', data.message)
             navigate(RouteSignIn)
-        } catch (error) {
+        },
+        onError: (error) => {
             showToast('error', error.message)
-        }
-    }
+        },
+    })
 
     return (
         <div className='flex justify-center items-center h-screen w-screen'>
@@ -64,7 +61,10 @@ const SignUp = () => {
                     </div>
                 </div>
                 <FormProvider {...form}>
-                    <form onSubmit={form.handleSubmit(onSubmit)} className="w-full max-w-sm space-y-4">
+                    <form
+                        onSubmit={form.handleSubmit((values) => registerMutation.mutate(values))}
+                        className="w-full max-w-sm space-y-4"
+                    >
                         <div className='flex flex-col gap-2'>
                             <label className="text-sm font-medium">Nombre</label>
                             <Input
@@ -108,7 +108,13 @@ const SignUp = () => {
                             )}
                         </div>
                         <div className='mt-5'>
-                            <Button type="submit" className='w-full'>Crear Cuenta</Button>
+                            <Button
+                                type="submit"
+                                className='w-full'
+                                disabled={registerMutation.isPending}
+                            >
+                                {registerMutation.isPending ? 'Creando cuenta...' : 'Crear Cuenta'}
+                            </Button>
                             <div className='mt-3 text-sm flex justify-center items-center gap-2'>
                                 <p>¿Ya tienes una cuenta?</p>
                                 <Link className='text-blue-500 hover:underline' to={RouteSignIn}>Inicia sesión aquí</Link>

--- a/frontend/src/store/useUserStore.js
+++ b/frontend/src/store/useUserStore.js
@@ -1,0 +1,17 @@
+import { create } from "zustand";
+import { persist, createJSONStorage } from "zustand/middleware";
+
+export const useUserStore = create(
+    persist(
+        (set) => ({
+            isLogginIn: false,
+            user: {},
+            setUser: (user) => set({ isLogginIn: true, user }),
+            removeUser: () => set({ isLogginIn: false, user: {} })
+        }),
+        {
+            name: 'user-storage',
+            storage: createJSONStorage(() => sessionStorage)
+        }
+    )
+)


### PR DESCRIPTION
…Query

Added frontend/src/store/useUserStore.js: zustand store with persist using sessionStorage (key: user-storage). Wrapped app with QueryClientProvider in main.jsx to enable TanStack Query. Updated auth flows to use TanStack Query mutations and central store: GoogleLogin.jsx — useMutation for Google login; calls setUser on success. SignIn.jsx — login mutation; sets store user on success. SignUp.jsx — registration uses TanStack mutation; GoogleLogin kept. Updated dependencies in package.json and package-lock.json to include zustand and @tanstack/react-query. Purpose: persist login state (session-scoped) across reloads and standardize async auth calls with TanStack Query for clearer state and network handling.