### PR TITLE
Integrate shadcn Dropdown and add logout API

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, HttpCode, HttpStatus, Post, Res } from '@nestjs/common';
+import { Body, Controller, Get, HttpCode, HttpStatus, Post, Res } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { RegisterDto } from './dto/register.dto';
 import { LoginDto } from './dto/login.dto';
@@ -25,5 +25,11 @@ export class AuthController {
     @HttpCode(HttpStatus.OK)
     googleLogin(@Body() body: GoogleLoginDto, @Res({ passthrough: true }) res: express.Response) {
         return this.authService.googleLogin(body.name, body.email, body.avatar ?? '', res);
+    }
+
+    @Get('logout')
+    @HttpCode(HttpStatus.OK)
+    logout(@Res({ passthrough: true }) res: express.Response) {
+        return this.authService.logout(res);
     }
 }

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -10,7 +10,7 @@ export class AuthService {
         private readonly usersService: UsersService,
         private readonly jwtService: JwtService
     ) { }
-    
+
     async register(name: string, email: string, password: string, confirmPassword: string) {
         try {
             if (password !== confirmPassword) {
@@ -106,5 +106,18 @@ export class AuthService {
             const message = error instanceof Error ? error.message : 'Error interno del servidor';
             throw new InternalServerErrorException(message);
         }
+    }
+
+    async logout(res: Response) {
+        const isProduction = process.env.NODE_ENV === 'production';
+
+        res.clearCookie('access_token', {
+            httpOnly: true,
+            secure: isProduction,
+            sameSite: isProduction ? 'none' : 'strict',
+            path: '/',
+        });
+
+        return { success: true, message: 'Cierre de sesión exitoso.' };
     }
 }

--- a/backend/src/auth/dto/google-login.dto.ts
+++ b/backend/src/auth/dto/google-login.dto.ts
@@ -1,4 +1,4 @@
-import { IsEmail, IsOptional, IsString, IsUrl } from 'class-validator';
+import { IsEmail, IsOptional, IsString } from 'class-validator';
 
 export class GoogleLoginDto {
     @IsString({ message: 'El nombre debe ser un texto.' })
@@ -8,6 +8,6 @@ export class GoogleLoginDto {
     email!: string;
 
     @IsOptional()
-    @IsUrl({}, { message: 'El avatar debe ser una URL válida.' })
+    @IsString()
     avatar?: string;
 }

--- a/frontend/src/components/GoogleLogin.jsx
+++ b/frontend/src/components/GoogleLogin.jsx
@@ -18,6 +18,8 @@ const GoogleLogin = () => {
         mutationFn: async () => {
             const googleResponse = await signInWithPopup(auth, provider)
             const user = googleResponse.user
+            console.log('Google User:', user)
+            console.log('Photo URL:', user.photoURL)
             const response = await fetch(`${getEnv('VITE_BASE_API_URL')}/auth/google-login`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
@@ -25,7 +27,7 @@ const GoogleLogin = () => {
                 body: JSON.stringify({
                     name: user.displayName,
                     email: user.email,
-                    avatar: user.photoURL,
+                    avatar: user.photoURL || '',
                 }),
             })
             const data = await response.json()

--- a/frontend/src/components/Topbar.jsx
+++ b/frontend/src/components/Topbar.jsx
@@ -1,12 +1,57 @@
 import React from 'react'
 import logo from '@/assets/images/logo.png'
 import { Button } from './ui/button'
-import { Link } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 import { MdLogin } from 'react-icons/md'
 import SearchBox from './SearchBox'
-import { RouteSignIn } from '@/helpers/RouteName'
+import { RouteIndex, RouteSignIn } from '@/helpers/RouteName'
+import { useUserStore } from '@/store/useUserStore'
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuGroup,
+    DropdownMenuItem,
+    DropdownMenuLabel,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import usericon from '@/assets/images/user.png'
+import { FaRegUser } from 'react-icons/fa6'
+import { FaPlus } from 'react-icons/fa6'
+import { IoLogOutOutline } from 'react-icons/io5'
+import { useMutation } from '@tanstack/react-query'
+import { showToast } from '@/helpers/showToast'
+import { getEnv } from '@/helpers/getEnv'
 
 const Topbar = () => {
+
+    const user = useUserStore((state) => state.user)
+    const isLogginIn = useUserStore((state) => state.isLogginIn)
+    const navigate = useNavigate()
+
+    const removeUser = useUserStore((state) => state.removeUser)
+
+    const handleLogout = useMutation({
+        mutationFn: async () => {
+            const response = await fetch(`${getEnv('VITE_BASE_API_URL')}/auth/logout`, {
+                method: 'GET',
+                credentials: 'include',
+            })
+            const data = await response.json()
+            if (!response.ok) throw new Error(data.message)
+            return data
+        },
+        onSuccess: (data) => {
+            removeUser()
+            showToast('success', data.message)
+            navigate(RouteIndex)
+        },
+        onError: (error) => {
+            showToast('error', error.message)
+        },
+    })
+
     return (
         <div className='flex justify-between items-center h-16 fixed w-full z-20 px-5 border-b bg-slate-100'>
             <div>
@@ -16,12 +61,54 @@ const Topbar = () => {
                 <SearchBox />
             </div>
             <div>
-                <Button asChild className='rounded-full h-10'>
-                    <Link to={RouteSignIn}>
-                        <MdLogin />
-                        Iniciar Sesión
-                    </Link>
-                </Button>
+                {!isLogginIn ?
+                    <Button asChild className='rounded-full h-10'>
+                        <Link to={RouteSignIn}>
+                            <MdLogin />
+                            Iniciar Sesión
+                        </Link>
+                    </Button>
+                    : <>
+                        <DropdownMenu>
+                            <DropdownMenuTrigger asChild>
+                                <Button className="!after:border-transparent bg-slate-100 hover:bg-slate-300 cursor-pointer">
+                                    <Avatar variant="muted">
+                                        <AvatarImage src={user.avatar || usericon} />
+                                        <AvatarFallback>CN</AvatarFallback>
+                                    </Avatar>
+                                </Button>
+                            </DropdownMenuTrigger>
+                            <DropdownMenuContent className="w-56">
+                                <DropdownMenuGroup>
+                                    <DropdownMenuLabel className="flex flex-col gap-1 py-2">
+                                        <p className="font-semibold truncate">{user.name}</p>
+                                        <p className='text-xs text-gray-600 truncate'>{user.email}</p>
+                                    </DropdownMenuLabel>
+                                    <DropdownMenuSeparator />
+                                    <DropdownMenuItem asChild className='cursor-pointer'>
+                                        <Link to=''>
+                                            <FaRegUser className='mr-2' />
+                                            <span>Perfil</span>
+                                        </Link>
+                                    </DropdownMenuItem>
+                                    <DropdownMenuItem asChild className='cursor-pointer'>
+                                        <Link to=''>
+                                            <FaPlus className='mr-2' />
+                                            <span>Crear Blog</span>
+                                        </Link>
+                                    </DropdownMenuItem>
+                                    <DropdownMenuSeparator />
+                                    <DropdownMenuItem asChild className='cursor-pointer'>
+                                        <button onClick={() => handleLogout.mutate()} className='w-full text-left flex items-center'>
+                                            <IoLogOutOutline color='red' className='mr-2' />
+                                            <span className='text-red-600'>Cerrar Sesión</span>
+                                        </button>
+                                    </DropdownMenuItem>
+                                </DropdownMenuGroup>
+                            </DropdownMenuContent>
+                        </DropdownMenu>
+                    </>
+                }
             </div>
         </div>
     )

--- a/frontend/src/components/ui/avatar.jsx
+++ b/frontend/src/components/ui/avatar.jsx
@@ -1,0 +1,112 @@
+import * as React from "react"
+import { Avatar as AvatarPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Avatar({
+  className,
+  size = "default",
+  variant = "default",
+  ...props
+}) {
+  const variantStyles = {
+    default: "after:border after:border-border after:mix-blend-darken dark:after:mix-blend-lighten",
+    muted: "!after:border-transparent bg-slate-100"
+  }
+
+  return (
+    <AvatarPrimitive.Root
+      data-slot="avatar"
+      data-size={size}
+      className={cn(
+        "group/avatar relative flex size-8 shrink-0 rounded-full select-none after:absolute after:inset-0 after:rounded-full data-[size=lg]:size-10 data-[size=sm]:size-6",
+        variantStyles[variant],
+        className
+      )}
+      {...props} />
+  );
+}
+
+function AvatarImage({
+  className,
+  ...props
+}) {
+  return (
+    <AvatarPrimitive.Image
+      data-slot="avatar-image"
+      className={cn("aspect-square size-full rounded-full object-cover", className)}
+      {...props} />
+  );
+}
+
+function AvatarFallback({
+  className,
+  ...props
+}) {
+  return (
+    <AvatarPrimitive.Fallback
+      data-slot="avatar-fallback"
+      className={cn(
+        "flex size-full items-center justify-center rounded-full bg-muted text-sm text-muted-foreground group-data-[size=sm]/avatar:text-xs",
+        className
+      )}
+      {...props} />
+  );
+}
+
+function AvatarBadge({
+  className,
+  ...props
+}) {
+  return (
+    <span
+      data-slot="avatar-badge"
+      className={cn(
+        "absolute right-0 bottom-0 z-10 inline-flex items-center justify-center rounded-full bg-primary text-primary-foreground bg-blend-color ring-2 ring-background select-none",
+        "group-data-[size=sm]/avatar:size-2 group-data-[size=sm]/avatar:[&>svg]:hidden",
+        "group-data-[size=default]/avatar:size-2.5 group-data-[size=default]/avatar:[&>svg]:size-2",
+        "group-data-[size=lg]/avatar:size-3 group-data-[size=lg]/avatar:[&>svg]:size-2",
+        className
+      )}
+      {...props} />
+  );
+}
+
+function AvatarGroup({
+  className,
+  ...props
+}) {
+  return (
+    <div
+      data-slot="avatar-group"
+      className={cn(
+        "group/avatar-group flex -space-x-2 *:data-[slot=avatar]:ring-2 *:data-[slot=avatar]:ring-background",
+        className
+      )}
+      {...props} />
+  );
+}
+
+function AvatarGroupCount({
+  className,
+  ...props
+}) {
+  return (
+    <div
+      data-slot="avatar-group-count"
+      className={cn(
+        "relative flex size-8 shrink-0 items-center justify-center rounded-full bg-muted text-sm text-muted-foreground ring-2 ring-background group-has-data-[size=lg]/avatar-group:size-10 group-has-data-[size=sm]/avatar-group:size-6 [&>svg]:size-4 group-has-data-[size=lg]/avatar-group:[&>svg]:size-5 group-has-data-[size=sm]/avatar-group:[&>svg]:size-3",
+        className
+      )}
+      {...props} />
+  );
+}
+
+export {
+  Avatar,
+  AvatarImage,
+  AvatarFallback,
+  AvatarGroup,
+  AvatarGroupCount,
+  AvatarBadge,
+}

--- a/frontend/src/components/ui/dropdown-menu.jsx
+++ b/frontend/src/components/ui/dropdown-menu.jsx
@@ -1,0 +1,235 @@
+import * as React from "react"
+import { DropdownMenu as DropdownMenuPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+import { CheckIcon, ChevronRightIcon } from "lucide-react"
+
+function DropdownMenu({
+  ...props
+}) {
+  return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />;
+}
+
+function DropdownMenuPortal({
+  ...props
+}) {
+  return (<DropdownMenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />);
+}
+
+function DropdownMenuTrigger({
+  ...props
+}) {
+  return (<DropdownMenuPrimitive.Trigger data-slot="dropdown-menu-trigger" {...props} />);
+}
+
+function DropdownMenuContent({
+  className,
+  align = "start",
+  sideOffset = 4,
+  ...props
+}) {
+  return (
+    <DropdownMenuPrimitive.Portal>
+      <DropdownMenuPrimitive.Content
+        data-slot="dropdown-menu-content"
+        sideOffset={sideOffset}
+        align={align}
+        className={cn(
+          "z-50 max-h-(--radix-dropdown-menu-content-available-height) w-(--radix-dropdown-menu-trigger-width) min-w-32 origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:overflow-hidden data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          className
+        )}
+        {...props} />
+    </DropdownMenuPrimitive.Portal>
+  );
+}
+
+function DropdownMenuGroup({
+  ...props
+}) {
+  return (<DropdownMenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />);
+}
+
+function DropdownMenuItem({
+  className,
+  inset,
+  variant = "default",
+  ...props
+}) {
+  return (
+    <DropdownMenuPrimitive.Item
+      data-slot="dropdown-menu-item"
+      data-inset={inset}
+      data-variant={variant}
+      className={cn(
+        "group/dropdown-menu-item relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:pl-8 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 data-[variant=destructive]:*:[svg]:text-destructive",
+        className
+      )}
+      {...props} />
+  );
+}
+
+function DropdownMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  inset,
+  ...props
+}) {
+  return (
+    <DropdownMenuPrimitive.CheckboxItem
+      data-slot="dropdown-menu-checkbox-item"
+      data-inset={inset}
+      className={cn(
+        "relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:pl-8 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      checked={checked}
+      {...props}>
+      <span
+        className="pointer-events-none absolute right-2 flex items-center justify-center"
+        data-slot="dropdown-menu-checkbox-item-indicator">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CheckIcon />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.CheckboxItem>
+  );
+}
+
+function DropdownMenuRadioGroup({
+  ...props
+}) {
+  return (<DropdownMenuPrimitive.RadioGroup data-slot="dropdown-menu-radio-group" {...props} />);
+}
+
+function DropdownMenuRadioItem({
+  className,
+  children,
+  inset,
+  ...props
+}) {
+  return (
+    <DropdownMenuPrimitive.RadioItem
+      data-slot="dropdown-menu-radio-item"
+      data-inset={inset}
+      className={cn(
+        "relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:pl-8 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}>
+      <span
+        className="pointer-events-none absolute right-2 flex items-center justify-center"
+        data-slot="dropdown-menu-radio-item-indicator">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CheckIcon />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.RadioItem>
+  );
+}
+
+function DropdownMenuLabel({
+  className,
+  inset,
+  ...props
+}) {
+  return (
+    <DropdownMenuPrimitive.Label
+      data-slot="dropdown-menu-label"
+      data-inset={inset}
+      className={cn(
+        "px-2 py-1.5 text-xs font-medium text-muted-foreground data-inset:pl-8",
+        className
+      )}
+      {...props} />
+  );
+}
+
+function DropdownMenuSeparator({
+  className,
+  ...props
+}) {
+  return (
+    <DropdownMenuPrimitive.Separator
+      data-slot="dropdown-menu-separator"
+      className={cn("-mx-1 my-1 h-px bg-border", className)}
+      {...props} />
+  );
+}
+
+function DropdownMenuShortcut({
+  className,
+  ...props
+}) {
+  return (
+    <span
+      data-slot="dropdown-menu-shortcut"
+      className={cn(
+        "ml-auto text-xs tracking-widest text-muted-foreground group-focus/dropdown-menu-item:text-accent-foreground",
+        className
+      )}
+      {...props} />
+  );
+}
+
+function DropdownMenuSub({
+  ...props
+}) {
+  return <DropdownMenuPrimitive.Sub data-slot="dropdown-menu-sub" {...props} />;
+}
+
+function DropdownMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}) {
+  return (
+    <DropdownMenuPrimitive.SubTrigger
+      data-slot="dropdown-menu-sub-trigger"
+      data-inset={inset}
+      className={cn(
+        "flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:pl-8 data-open:bg-accent data-open:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}>
+      {children}
+      <ChevronRightIcon className="ml-auto" />
+    </DropdownMenuPrimitive.SubTrigger>
+  );
+}
+
+function DropdownMenuSubContent({
+  className,
+  ...props
+}) {
+  return (
+    <DropdownMenuPrimitive.SubContent
+      data-slot="dropdown-menu-sub-content"
+      className={cn(
+        "z-50 min-w-24 origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md bg-popover p-1 text-popover-foreground shadow-lg ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+        className
+      )}
+      {...props} />
+  );
+}
+
+export {
+  DropdownMenu,
+  DropdownMenuPortal,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuLabel,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
+}


### PR DESCRIPTION
Add shadcn-style DropdownMenu UI component and exports for accessible menu primitives. Update Topbar to use the Dropdown and add a logout menu action that calls GET /auth/logout and clears client state on success. Add GET /auth/logout endpoint in AuthController and implement AuthService.logout to clear the access_token cookie server-side. Reason: provide a consistent accessible user-menu (shadcn/Radix pattern) and implement proper server-side session termination; frontend handles client cleanup and redirect.