### PR TITLE
feat(categories): scaffold backend CRUD and add frontend admin UI

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -5,6 +5,7 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
 import { MongooseModule } from '@nestjs/mongoose';
 import { UsersModule } from './users/users.module';
 import { AuthModule } from './auth/auth.module';
+import { CategoryModule } from './categories/category.module';
 
 @Module({
   imports: [
@@ -33,6 +34,7 @@ import { AuthModule } from './auth/auth.module';
     }),
     UsersModule,
     AuthModule,
+    CategoryModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/categories/category.controller.spec.ts
+++ b/backend/src/categories/category.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CategoryController } from './category.controller';
+
+describe('CategoryController', () => {
+  let controller: CategoryController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [CategoryController],
+    }).compile();
+
+    controller = module.get<CategoryController>(CategoryController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/backend/src/categories/category.controller.ts
+++ b/backend/src/categories/category.controller.ts
@@ -1,0 +1,64 @@
+import { Body, Controller, Delete, Get, HttpCode, HttpStatus, Param, Post, Put } from '@nestjs/common';
+import { CategoryService } from './category.service';
+import { CreateCategoryDto } from './dto/create-category.dto';
+import { UpdateCategoryDto } from './dto/update-category.dto';
+
+@Controller('category')
+export class CategoryController {
+    constructor(private readonly categoriesService: CategoryService) { }
+
+    @Post('add')
+    @HttpCode(HttpStatus.OK)
+    async addCategory(@Body() dto: CreateCategoryDto) {
+        const category = await this.categoriesService.create(dto);
+        return {
+            success: true,
+            message: 'Categoría agregada exitosamente.',
+            category,
+        };
+    }
+
+    @Get('all')
+    @HttpCode(HttpStatus.OK)
+    async getAllCategory() {
+        const categories = await this.categoriesService.findAll();
+        return {
+            success: true,
+            categories,
+        };
+    }
+
+    @Get('show/:categoryId')
+    @HttpCode(HttpStatus.OK)
+    async showCategory(@Param('categoryId') categoryId: string) {
+        const category = await this.categoriesService.findById(categoryId);
+        return {
+            success: true,
+            category,
+        };
+    }
+
+    @Put('update/:categoryId')
+    @HttpCode(HttpStatus.OK)
+    async updateCategory(
+        @Param('categoryId') categoryId: string,
+        @Body() dto: UpdateCategoryDto,
+    ) {
+        const category = await this.categoriesService.updateById(categoryId, dto);
+        return {
+            success: true,
+            message: 'Categoría actualizada exitosamente.',
+            category,
+        };
+    }
+
+    @Delete('delete/:categoryId')
+    @HttpCode(HttpStatus.OK)
+    async deleteCategory(@Param('categoryId') categoryId: string) {
+        await this.categoriesService.deleteById(categoryId);
+        return {
+            success: true,
+            message: 'Categoría eliminada exitosamente.',
+        };
+    }
+}

--- a/backend/src/categories/category.module.ts
+++ b/backend/src/categories/category.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { CategoryService } from './category.service';
+import { CategoryController } from './category.controller';
+import { MongooseModule } from '@nestjs/mongoose';
+import { Category, CategorySchema } from './schemas/category.schema';
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([{ name: Category.name, schema: CategorySchema }]),
+  ],
+  providers: [CategoryService],
+  controllers: [CategoryController],
+  exports: [CategoryService],
+})
+export class CategoryModule { }

--- a/backend/src/categories/category.service.spec.ts
+++ b/backend/src/categories/category.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CategoriesService } from './category.service';
+
+describe('CategoriesService', () => {
+  let service: CategoriesService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [CategoriesService],
+    }).compile();
+
+    service = module.get<CategoriesService>(CategoriesService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/backend/src/categories/category.service.ts
+++ b/backend/src/categories/category.service.ts
@@ -1,0 +1,83 @@
+import { ConflictException, Injectable, InternalServerErrorException, NotFoundException } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { Category, CategoryDocument } from './schemas/category.schema';
+import { CreateCategoryDto } from './dto/create-category.dto';
+import { UpdateCategoryDto } from './dto/update-category.dto';
+
+@Injectable()
+export class CategoryService {
+    constructor(
+        @InjectModel(Category.name) private categoryModel: Model<CategoryDocument>,
+    ) { }
+
+    async create(dto: CreateCategoryDto): Promise<CategoryDocument> {
+        try {
+            const existing = await this.categoryModel.findOne({ slug: dto.slug });
+            if (existing) {
+                throw new ConflictException('Ya existe una categoría con esa ficha (slug).');
+            }
+
+            const category = new this.categoryModel(dto);
+            return await category.save();
+        } catch (error) {
+            if (error instanceof ConflictException) throw error;
+            const message = error instanceof Error ? error.message : 'Error interno del servidor';
+            throw new InternalServerErrorException(message);
+        }
+    }
+
+    async findAll(): Promise<CategoryDocument[]> {
+        try {
+            return await this.categoryModel.find().sort({ name: 1 }).lean().exec();
+        } catch (error) {
+            const message = error instanceof Error ? error.message : 'Error interno del servidor';
+            throw new InternalServerErrorException(message);
+        }
+    }
+
+    async findById(categoryId: string): Promise<CategoryDocument> {
+        try {
+            const category = await this.categoryModel.findById(categoryId);
+            if (!category) {
+                throw new NotFoundException('Datos no encontrados.');
+            }
+            return category;
+        } catch (error) {
+            if (error instanceof NotFoundException) throw error;
+            const message = error instanceof Error ? error.message : 'Error interno del servidor';
+            throw new InternalServerErrorException(message);
+        }
+    }
+
+    async updateById(categoryId: string, dto: UpdateCategoryDto): Promise<CategoryDocument> {
+        try {
+            const category = await this.categoryModel.findByIdAndUpdate(
+                categoryId,
+                dto,
+                { new: true },
+            );
+            if (!category) {
+                throw new NotFoundException('Datos no encontrados.');
+            }
+            return category;
+        } catch (error) {
+            if (error instanceof NotFoundException) throw error;
+            const message = error instanceof Error ? error.message : 'Error interno del servidor';
+            throw new InternalServerErrorException(message);
+        }
+    }
+
+    async deleteById(categoryId: string): Promise<void> {
+        try {
+            const category = await this.categoryModel.findByIdAndDelete(categoryId);
+            if (!category) {
+                throw new NotFoundException('Datos no encontrados.');
+            }
+        } catch (error) {
+            if (error instanceof NotFoundException) throw error;
+            const message = error instanceof Error ? error.message : 'Error interno del servidor';
+            throw new InternalServerErrorException(message);
+        }
+    }
+}

--- a/backend/src/categories/dto/create-category.dto.ts
+++ b/backend/src/categories/dto/create-category.dto.ts
@@ -1,0 +1,18 @@
+import { IsOptional, IsString, Matches, MinLength } from 'class-validator';
+
+export class CreateCategoryDto {
+    @IsString({ message: 'El nombre debe ser un texto.' })
+    @MinLength(3, { message: 'El nombre debe tener al menos 3 caracteres.' })
+    name: string;
+
+    @IsString({ message: 'La ficha debe ser un texto.' })
+    @MinLength(3, { message: 'La ficha debe tener al menos 3 caracteres.' })
+    @Matches(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, {
+        message: 'La ficha solo puede contener letras minúsculas, números y guiones.',
+    })
+    slug: string;
+
+    @IsOptional()
+    @IsString({ message: 'El ícono debe ser un texto.' })
+    icon?: string;
+}

--- a/backend/src/categories/dto/update-category.dto.ts
+++ b/backend/src/categories/dto/update-category.dto.ts
@@ -1,0 +1,20 @@
+import { IsOptional, IsString, Matches, MinLength } from 'class-validator';
+
+export class UpdateCategoryDto {
+    @IsOptional()
+    @IsString({ message: 'El nombre debe ser un texto.' })
+    @MinLength(3, { message: 'El nombre debe tener al menos 3 caracteres.' })
+    name?: string;
+
+    @IsOptional()
+    @IsString({ message: 'La ficha debe ser un texto.' })
+    @MinLength(3, { message: 'La ficha debe tener al menos 3 caracteres.' })
+    @Matches(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, {
+        message: 'La ficha solo puede contener letras minúsculas, números y guiones.',
+    })
+    slug?: string;
+
+    @IsOptional()
+    @IsString({ message: 'El ícono debe ser un texto.' })
+    icon?: string;
+}

--- a/backend/src/categories/schemas/category.schema.ts
+++ b/backend/src/categories/schemas/category.schema.ts
@@ -1,0 +1,34 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { HydratedDocument } from 'mongoose';
+
+export type CategoryDocument = HydratedDocument<Category>;
+
+@Schema({
+    timestamps: true,
+    collection: 'categories',
+})
+export class Category {
+    @Prop({
+        type: String,
+        required: true,
+        trim: true,
+    })
+    name: string;
+
+    @Prop({
+        type: String,
+        required: true,
+        unique: true,
+        trim: true,
+    })
+    slug: string;
+
+    @Prop({
+        type: String,
+        trim: true,
+        default: null,
+    })
+    icon?: string; 
+}
+
+export const CategorySchema = SchemaFactory.createForClass(Category);

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -25,6 +25,7 @@
         "react-router-dom": "^7.14.1",
         "react-toastify": "^11.1.0",
         "shadcn": "^4.3.0",
+        "slugify": "^1.6.9",
         "tailwind-merge": "^3.5.0",
         "tailwindcss": "^4.2.2",
         "tw-animate-css": "^1.4.0",
@@ -8395,6 +8396,15 @@
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "license": "MIT"
+    },
+    "node_modules/slugify": {
+      "version": "1.6.9",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.9.tgz",
+      "integrity": "sha512-vZ7rfeehZui7wQs438JXBckYLkIIdfHOXsaVEUMyS5fHo1483l1bMdo0EDSWYclY0yZKFOipDy4KHuKs6ssvdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
     "node_modules/source-map": {
       "version": "0.6.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,6 +27,7 @@
     "react-router-dom": "^7.14.1",
     "react-toastify": "^11.1.0",
     "shadcn": "^4.3.0",
+    "slugify": "^1.6.9",
     "tailwind-merge": "^3.5.0",
     "tailwindcss": "^4.2.2",
     "tw-animate-css": "^1.4.0",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,11 +1,14 @@
 import React from 'react'
 import { BrowserRouter, Route, Routes } from 'react-router-dom'
 import Layout from './layout/Layout'
-import { RouteIndex, RouteProfile, RouteSignIn, RouteSignUp } from './helpers/RouteName'
+import { RouteAddCategory, RouteCategoryDetails, RouteEditCategory, RouteIndex, RouteProfile, RouteSignIn, RouteSignUp } from './helpers/RouteName'
 import Index from './pages/Index'
 import SignIn from './pages/Signin'
 import SignUp from './pages/SignUp'
 import Profile from './pages/Profile'
+import AddCategory from './pages/category/AddCategory'
+import EditCategory from './pages/category/EditCategory'
+import CategoryDetails from './pages/category/CategoryDetails'
 
 const App = () => {
   return (
@@ -15,6 +18,9 @@ const App = () => {
           <Route path={RouteIndex} element={<Layout/>}>
             <Route index element={<Index />} />
             <Route path={RouteProfile} element={<Profile />} />
+            <Route path={RouteAddCategory} element={<AddCategory />} />
+            <Route path={RouteCategoryDetails} element={<CategoryDetails />} />
+            <Route path={RouteEditCategory()} element={<EditCategory />} />
           </Route>
           <Route path={RouteSignIn} element={<SignIn />} />
           <Route path={RouteSignUp} element={<SignUp />} />

--- a/frontend/src/components/AppSidebar.jsx
+++ b/frontend/src/components/AppSidebar.jsx
@@ -17,6 +17,7 @@ import { BiCategoryAlt } from 'react-icons/bi'
 import { FaBlog, FaRegComment } from 'react-icons/fa6'
 import { LuUsers } from 'react-icons/lu'
 import { GoDot } from 'react-icons/go'
+import { RouteCategoryDetails } from '@/helpers/RouteName'
 
 const AppSidebar = () => {
     return (
@@ -41,7 +42,7 @@ const AppSidebar = () => {
                         </SidebarMenuItem>
                         <SidebarMenuItem>
                             <SidebarMenuButton asChild>
-                                <Link to="">
+                                <Link to={RouteCategoryDetails}>
                                     <BiCategoryAlt />
                                     <span>Categorias</span>
                                 </Link>

--- a/frontend/src/components/ui/table.jsx
+++ b/frontend/src/components/ui/table.jsx
@@ -1,0 +1,121 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Table({
+  className,
+  ...props
+}) {
+  return (
+    <div data-slot="table-container" className="relative w-full overflow-x-auto">
+      <table
+        data-slot="table"
+        className={cn("w-full caption-bottom text-sm", className)}
+        {...props} />
+    </div>
+  );
+}
+
+function TableHeader({
+  className,
+  ...props
+}) {
+  return (
+    <thead
+      data-slot="table-header"
+      className={cn("[&_tr]:border-b", className)}
+      {...props} />
+  );
+}
+
+function TableBody({
+  className,
+  ...props
+}) {
+  return (
+    <tbody
+      data-slot="table-body"
+      className={cn("[&_tr:last-child]:border-0", className)}
+      {...props} />
+  );
+}
+
+function TableFooter({
+  className,
+  ...props
+}) {
+  return (
+    <tfoot
+      data-slot="table-footer"
+      className={cn("border-t bg-muted/50 font-medium [&>tr]:last:border-b-0", className)}
+      {...props} />
+  );
+}
+
+function TableRow({
+  className,
+  ...props
+}) {
+  return (
+    <tr
+      data-slot="table-row"
+      className={cn(
+        "border-b transition-colors hover:bg-muted/50 has-aria-expanded:bg-muted/50 data-[state=selected]:bg-muted",
+        className
+      )}
+      {...props} />
+  );
+}
+
+function TableHead({
+  className,
+  ...props
+}) {
+  return (
+    <th
+      data-slot="table-head"
+      className={cn(
+        "h-10 px-2 text-left align-middle font-medium whitespace-nowrap text-foreground [&:has([role=checkbox])]:pr-0",
+        className
+      )}
+      {...props} />
+  );
+}
+
+function TableCell({
+  className,
+  ...props
+}) {
+  return (
+    <td
+      data-slot="table-cell"
+      className={cn(
+        "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0",
+        className
+      )}
+      {...props} />
+  );
+}
+
+function TableCaption({
+  className,
+  ...props
+}) {
+  return (
+    <caption
+      data-slot="table-caption"
+      className={cn("mt-4 text-sm text-muted-foreground", className)}
+      {...props} />
+  );
+}
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+}

--- a/frontend/src/helpers/RouteName.js
+++ b/frontend/src/helpers/RouteName.js
@@ -2,3 +2,12 @@ export const RouteIndex = '/'
 export const RouteSignIn = '/sign-in'
 export const RouteSignUp = '/sign-up'
 export const RouteProfile = '/profile'
+export const RouteCategoryDetails = '/categories'
+export const RouteAddCategory = '/category/add'
+export const RouteEditCategory = (category_id) => {
+    if (category_id) {
+        return `/category/edit/${category_id}`
+    } else {
+        return `/category/edit/:category_id`
+    }
+}

--- a/frontend/src/helpers/handleDelete.js
+++ b/frontend/src/helpers/handleDelete.js
@@ -1,0 +1,20 @@
+export const deleteData = async (endpoint) => {
+    const c = confirm('¿Seguro que quiere eliminarlo?')
+    if (c) {
+        try {
+            const response = await fetch(endpoint, {
+                method: 'DELETE',
+                credentials: 'include'
+            })
+            const data = await response.json()
+            if (!response.ok) {
+                throw new Error(response.statusText)
+            }
+        } catch (error) {
+            console.log(error);
+            return false
+        }
+    } else {
+        return false
+    }
+}

--- a/frontend/src/helpers/resolveIcon.jsx
+++ b/frontend/src/helpers/resolveIcon.jsx
@@ -1,0 +1,15 @@
+import * as Ai from 'react-icons/ai'
+import * as Bs from 'react-icons/bs'
+import * as Fa6 from 'react-icons/fa6'
+import * as Gi from 'react-icons/gi'
+import * as Gr from 'react-icons/gr'
+import * as Pi from 'react-icons/pi'
+import * as Tb from 'react-icons/tb'
+import { GoDot } from 'react-icons/go'
+
+const ALL_ICONS = { ...Ai, ...Bs, ...Fa6, ...Gi, ...Gr, ...Pi, ...Tb }
+
+export const resolveIcon = (iconName, props = {}) => {
+    const Icon = iconName ? ALL_ICONS[iconName] : null
+    return Icon ? <Icon {...props} /> : <GoDot {...props} />
+}

--- a/frontend/src/pages/category/AddCategory.jsx
+++ b/frontend/src/pages/category/AddCategory.jsx
@@ -1,0 +1,152 @@
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { getEnv } from '@/helpers/getEnv'
+import { showToast } from '@/helpers/showToast'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useMutation } from '@tanstack/react-query'
+import React, { useEffect, useState } from 'react'
+import { FormProvider, useForm } from 'react-hook-form'
+import { resolveIcon } from '@/helpers/resolveIcon'
+import z from 'zod'
+import slugify from 'slugify'
+
+const ICON_OPTIONS = [
+    { name: 'FaCode', label: 'Fundamentos de Programación' },
+    { name: 'GrCycle', label: 'Técnicas de Programación' },
+    { name: 'GrCube', label: 'Prog. Orientada a Objetos' },
+    { name: 'TbCodeDots', label: 'Lenguajes de Programación' },
+    { name: 'TbBinaryTree', label: 'Estructuras de Datos' },
+    { name: 'BsServer', label: 'Bases de Datos Relacionales' },
+    { name: 'GiStack', label: 'Bases de Datos No Relacionales' },
+    { name: 'PiTreeView', label: 'Administración de BD' },
+    { name: 'FaLaptopCode', label: 'Desarrollo Frontend' },
+    { name: 'FaServer', label: 'Desarrollo Backend' },
+    { name: 'FaCodeBranch', label: 'Fundamentos de Ing. de Software' },
+    { name: 'GiCubeforce', label: 'Arquitectura de Software' },
+    { name: 'FaCheckToSlot', label: 'Calidad en el Desarrollo' },
+    { name: 'GrCloudSoftware', label: 'DevSecOps' },
+    { name: 'AiFillCode', label: 'Sistemas Operativos' },
+    { name: 'FaHexagonNodes', label: 'Análisis y Diseño de Algoritmos' },
+    { name: 'FaCodepen', label: 'HPC y Prog. Concurrente' },
+]
+
+const formSchema = z.object({
+    name: z.string().min(3, 'El nombre debe ser de al menos 3 caracteres.'),
+    slug: z.string().min(3, 'La ficha debe ser de al menos 3 caracteres.')
+})
+
+const AddCategory = () => {
+
+    const [selectedIcon, setSelectedIcon] = useState(null)
+
+    const form = useForm({
+        resolver: zodResolver(formSchema),
+        defaultValues: { name: '', slug: '' },
+    })
+
+    const nameValue = form.watch('name')
+
+    useEffect(() => {
+        if (nameValue) {
+            form.setValue('slug', slugify(nameValue, { lower: true, strict: true }), {
+                shouldValidate: true,
+            })
+        }
+    }, [nameValue])
+
+    const categoryMutation = useMutation({
+        mutationFn: async (values) => {
+            const response = await fetch(`${getEnv('VITE_BASE_API_URL')}/category/add`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ ...values, icon: selectedIcon }),
+            })
+            const data = await response.json()
+            if (!response.ok) throw new Error(data.message)
+            return data
+        },
+        onSuccess: (data) => {
+            form.reset()
+            setSelectedIcon(null)
+            showToast('success', data.message)
+        },
+        onError: (error) => {
+            showToast('error', error.message)
+        },
+    })
+
+    return (
+        <div>
+            <Card className='pt-5 max-w-3xl mx-auto bg-slate-100'>
+                <CardContent>
+                    <FormProvider {...form}>
+                        <form
+                            onSubmit={form.handleSubmit((values) => categoryMutation.mutate(values))}
+                            className="w-full space-y-4"
+                        >
+                            <div className='flex flex-col gap-2'>
+                                <label className="text-sm font-medium">Nombre</label>
+                                <Input
+                                    {...form.register("name")}
+                                    placeholder="Ingrese la categoria"
+                                />
+                                {form.formState.errors.name && (
+                                    <p className="text-sm text-red-500">{form.formState.errors.name.message}</p>
+                                )}
+                            </div>
+                            <div className='flex flex-col gap-2'>
+                                <label className="text-sm font-medium">Ficha</label>
+                                <Input
+                                    {...form.register("slug")}
+                                    placeholder="Ingrese la ficha"
+                                />
+                                {form.formState.errors.slug && (
+                                    <p className="text-sm text-red-500">{form.formState.errors.slug.message}</p>
+                                )}
+                            </div>
+                            <div className='flex flex-col gap-2'>
+                                <label className="text-sm font-medium">
+                                    Ícono{' '}
+                                    <span className="text-muted-foreground text-xs">(opcional)</span>
+                                </label>
+                                <div className='grid grid-cols-6 gap-2'>
+                                    {ICON_OPTIONS.map(({ name, label }) => (
+                                        <button
+                                            key={name}
+                                            type="button"
+                                            title={label}
+                                            onClick={() => setSelectedIcon(prev => prev === name ? null : name)}
+                                            className={`flex flex-col items-center gap-1 p-2 rounded-md border text-xs transition-colors ${selectedIcon === name
+                                                    ? 'bg-primary text-primary-foreground border-primary'
+                                                    : 'bg-white border-border hover:bg-slate-200'
+                                                }`}
+                                        >
+                                            {resolveIcon(name, { size: 20 })}
+                                        </button>
+                                    ))}
+                                </div>
+                                {selectedIcon && (
+                                    <p className="text-xs text-muted-foreground">
+                                        Seleccionado:{' '}
+                                        <code className="bg-slate-200 px-1 rounded">{selectedIcon}</code>
+                                        {' — '}{ICON_OPTIONS.find(i => i.name === selectedIcon)?.label}
+                                    </p>
+                                )}
+                            </div>
+                            <Button
+                                type="submit"
+                                className='w-full'
+                                disabled={categoryMutation.isPending}
+                            >
+                                {categoryMutation.isPending ? 'Guardando...' : 'Guardar'}
+                            </Button>
+                        </form>
+                    </FormProvider>
+                </CardContent>
+            </Card>
+        </div>
+    )
+}
+
+export default AddCategory

--- a/frontend/src/pages/category/CategoryDetails.jsx
+++ b/frontend/src/pages/category/CategoryDetails.jsx
@@ -1,0 +1,108 @@
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader } from '@/components/ui/card'
+import { RouteAddCategory, RouteEditCategory } from '@/helpers/RouteName'
+import React, { useState } from 'react'
+import { Link } from 'react-router-dom'
+import {
+    Table,
+    TableBody,
+    TableCaption,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from "@/components/ui/table"
+import { useFetch } from '@/hooks/useFetch'
+import { getEnv } from '@/helpers/getEnv'
+import Loading from '@/components/Loading'
+import { FiEdit } from "react-icons/fi";
+import { FaTrashAlt } from "react-icons/fa";
+import { deleteData } from '@/helpers/handleDelete'
+import { showToast } from '@/helpers/showToast'
+
+const CategoryDetails = () => {
+
+    const [refreshData, setRefreshData] = useState(false)
+
+    const { data: categoryData, loading, error } = useFetch(`${getEnv('VITE_BASE_API_URL')}/category/all`, {
+        method: 'GET',
+        credentials: 'include'
+    }, [refreshData])
+
+    const handleDelete = (id) => {
+        const response = deleteData(`${getEnv('VITE_BASE_API_URL')}/category/delete/${id}`)
+        if (response) {
+            setRefreshData(!refreshData)
+            showToast('success', 'Categoría eliminada correctamente.')
+        } else {
+            showToast('error', 'Error al eliminar la categoría.')
+        }
+    }
+
+    if (loading) return <Loading />
+
+    return (
+        <div>
+            <Card className='bg-slate-100'>
+                <CardHeader>
+                    <div>
+                        <Button asChild>
+                            <Link to={RouteAddCategory}>
+                                Agregar Categoría
+                            </Link>
+                        </Button>
+                    </div>
+                </CardHeader>
+                <CardContent>
+                    <Table>
+                        <TableCaption>Lista de Categorías.</TableCaption>
+                        <TableHeader>
+                            <TableRow>
+                                <TableHead className="font-bold">Categoría</TableHead>
+                                <TableHead className="font-bold">Ficha</TableHead>
+                                <TableHead className="font-bold">Acciones</TableHead>
+                            </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                            {categoryData?.categories?.length > 0 ?
+                                categoryData.categories.map(category => (
+                                    <TableRow key={category._id}>
+                                        <TableCell>{category.name}</TableCell>
+                                        <TableCell>{category.slug}</TableCell>
+                                        <TableCell className='flex gap-2'>
+                                            <Button
+                                                variant='outline'
+                                                className='bg-slate-100 hover:bg-violet-500 hover:text-white'
+                                                asChild
+                                            >
+                                                <Link to={RouteEditCategory(category._id)}>
+                                                    <FiEdit />
+                                                </Link>
+                                            </Button>
+                                            <Button
+                                                variant='outline'
+                                                className='bg-slate-100 hover:bg-violet-500 hover:text-white'
+                                                onClick={() => handleDelete(category._id)}
+                                                aria-label={`Eliminar ${category.name}`}
+                                            >
+                                                <FaTrashAlt />
+                                            </Button>
+                                        </TableCell>
+                                    </TableRow>
+                                ))
+                                :
+                                <TableRow>
+                                    <TableCell colSpan="3">
+                                        No se encontraron datos.
+                                    </TableCell>
+                                </TableRow>
+                            }
+                        </TableBody>
+                    </Table>
+                </CardContent>
+            </Card>
+        </div>
+    )
+}
+
+export default CategoryDetails

--- a/frontend/src/pages/category/EditCategory.jsx
+++ b/frontend/src/pages/category/EditCategory.jsx
@@ -1,0 +1,118 @@
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { getEnv } from '@/helpers/getEnv'
+import { showToast } from '@/helpers/showToast'
+import { useFetch } from '@/hooks/useFetch'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useMutation } from '@tanstack/react-query'
+import React, { useEffect } from 'react'
+import { FormProvider, useForm } from 'react-hook-form'
+import { useParams } from 'react-router-dom'
+import slugify from 'slugify'
+import z from 'zod'
+
+const formSchema = z.object({
+    name: z.string().min(3, 'El nombre debe ser de al menos 3 caracteres.'),
+    slug: z.string().min(3, 'La ficha debe ser de al menos 3 caracteres.'),
+})
+
+const EditCategory = () => {
+    const { category_id } = useParams()
+
+    const { data: categoryData } = useFetch(
+        `${getEnv('VITE_BASE_API_URL')}/category/show/${category_id}`,
+        { method: 'GET', credentials: 'include' },
+        [category_id],
+    )
+
+    const form = useForm({
+        resolver: zodResolver(formSchema),
+        defaultValues: { name: '', slug: '' },
+    })
+
+    const nameValue = form.watch('name')
+
+    useEffect(() => {
+        if (nameValue) {
+            form.setValue('slug', slugify(nameValue, { lower: true, strict: true }), {
+                shouldValidate: true,
+            })
+        }
+    }, [nameValue])
+
+    useEffect(() => {
+        if (categoryData?.category) {
+            form.setValue('name', categoryData.category.name)
+            form.setValue('slug', categoryData.category.slug)
+        }
+    }, [categoryData])
+
+    const categoryMutation = useMutation({
+        mutationFn: async (values) => {
+            const response = await fetch(
+                `${getEnv('VITE_BASE_API_URL')}/category/update/${category_id}`,
+                {
+                    method: 'PUT',
+                    headers: { 'Content-Type': 'application/json' },
+                    credentials: 'include',
+                    body: JSON.stringify(values),
+                },
+            )
+            const data = await response.json()
+            if (!response.ok) throw new Error(data.message)
+            return data
+        },
+        onSuccess: (data) => {
+            showToast('success', data.message)
+        },
+        onError: (error) => {
+            showToast('error', error.message)
+        },
+    })
+
+    return (
+        <div>
+            <Card className='pt-5 max-w-3xl mx-auto bg-slate-100'>
+                <CardContent>
+                    <FormProvider {...form}>
+                        <form
+                            onSubmit={form.handleSubmit((values) => categoryMutation.mutate(values))}
+                            className="w-full space-y-4"
+                        >
+                            <div className='flex flex-col gap-2'>
+                                <label className="text-sm font-medium">Nombre</label>
+                                <Input
+                                    {...form.register("name")}
+                                    placeholder="Ingrese la categoría"
+                                />
+                                {form.formState.errors.name && (
+                                    <p className="text-sm text-red-500">{form.formState.errors.name.message}</p>
+                                )}
+                            </div>
+                            <div className='flex flex-col gap-2'>
+                                <label className="text-sm font-medium">Ficha</label>
+                                <Input
+                                    {...form.register("slug")}
+                                    placeholder="Ingrese la ficha"
+                                />
+                                {form.formState.errors.slug && (
+                                    <p className="text-sm text-red-500">{form.formState.errors.slug.message}</p>
+                                )}
+                            </div>
+                            <Button
+                                type="submit"
+                                className='w-full'
+                                disabled={categoryMutation.isPending}
+                            >
+                                {categoryMutation.isPending ? 'Guardando...' : 'Guardar'}
+                            </Button>
+                        </form>
+                    </FormProvider>
+                </CardContent>
+            </Card>
+        </div>
+    )
+}
+
+export default EditCategory


### PR DESCRIPTION
Body:
Backend: add Category module, schema, service, controller, DTOs and tests — category.module.ts, category.schema.ts, category.service.ts, category.controller.ts, create-category.dto.ts, update-category.dto.ts, and app module registration app.module.ts. Frontend: add admin pages, UI and helpers for categories — CategoryDetails.jsx, AddCategory.jsx, EditCategory.jsx, table UI table.jsx, icon resolver resolveIcon.jsx, delete helper handleDelete.js, route entries and sidebar link (RouteName.js, App.jsx, AppSidebar.jsx), and slugify dependency (package.json). Purpose: initial admin CRUD scaffolding to list/add/edit/delete blog categories and provide API endpoints for category management.