### PR TITLE
Add homepage blog preview (BlogCard) and include author data

### DIFF
--- a/backend/src/blogs/blogs.service.ts
+++ b/backend/src/blogs/blogs.service.ts
@@ -52,7 +52,7 @@ export class BlogsService {
         try {
             return await this.blogModel
                 .find()
-                .populate('author', 'name')
+                .populate('author', 'name avatar role')
                 .populate('category', 'name')
                 .sort({ createdAt: -1 })
                 .lean()
@@ -67,6 +67,7 @@ export class BlogsService {
         try {
             const blog = await this.blogModel
                 .findById(blogId)
+                .populate('author', 'name avatar role')
                 .populate('category', 'name');
             if (!blog) {
                 throw new NotFoundException('Datos no encontrados.');

--- a/backend/src/common/interceptors/file-upload.interceptor.ts
+++ b/backend/src/common/interceptors/file-upload.interceptor.ts
@@ -2,7 +2,7 @@ import { FileInterceptor } from '@nestjs/platform-express';
 import { memoryStorage } from 'multer';
 import { UnsupportedMediaTypeException } from '@nestjs/common';
 
-const ALLOWED_MIMETYPES = ['image/png', 'image/jpg', 'image/jpeg', 'image/webp'];
+const ALLOWED_MIMETYPES = ['image/png', 'image/jpg', 'image/jpeg', 'image/webp', 'image/svg+xml'];
 
 export const ImageFileInterceptor = () =>
     FileInterceptor('file', {
@@ -10,7 +10,7 @@ export const ImageFileInterceptor = () =>
         fileFilter: (_req, file, cb) => {
             if (!ALLOWED_MIMETYPES.includes(file.mimetype)) {
                 return cb(
-                    new UnsupportedMediaTypeException('Solo se aceptan imágenes PNG, JPG, JPEG o WEBP.'),
+                    new UnsupportedMediaTypeException('Solo se aceptan imágenes PNG, JPG, JPEG, WEBP o SVG.'),
                     false,
                 );
             }

--- a/frontend/src/components/BlogCard.jsx
+++ b/frontend/src/components/BlogCard.jsx
@@ -1,0 +1,62 @@
+import React from 'react'
+import { Card, CardContent } from './ui/card'
+import { Badge } from './ui/badge'
+import { Avatar, AvatarImage, AvatarFallback } from './ui/avatar'
+import { FaRegCalendarAlt } from 'react-icons/fa'
+import userIcon from '@/assets/images/user.png'
+import { Link } from 'react-router-dom'
+
+const BlogCard = ({ props }) => {
+
+    const formatDate = (date) => {
+        return new Date(date).toLocaleDateString('es-ES', {
+            year: 'numeric',
+            month: 'long',
+            day: 'numeric'
+        })
+    }
+
+    const getInitials = (name) => {
+        return name
+            ?.split(' ')
+            .map(word => word[0])
+            .join('')
+            .toUpperCase()
+            .slice(0, 2) || 'U'
+    }
+
+    return (
+        <Link to={`/blog/${props.slug}`}>
+            <Card className='pt-5 hover:shadow-lg transition-shadow cursor-pointer bg-slate-100'>
+                <CardContent>
+                    <div className='flex items-center justify-between mb-2'>
+                        <div className='flex items-center gap-2'>
+                            <Avatar>
+                                <AvatarImage src={props.author?.avatar || userIcon} alt={props.author?.name} />
+                                <AvatarFallback>{getInitials(props.author?.name)}</AvatarFallback>
+                            </Avatar>
+                            <span className='font-medium'>{props.author?.name}</span>
+                        </div>
+                        {props.author?.role === 'admin' &&
+                            <Badge className='bg-violet-500 text-white hover:bg-violet-600'>Admin</Badge>
+                        }
+                    </div>
+                    <div className='my-2'>
+                        <img src={props.featuredImage} className='rounded w-full h-48 object-cover' />
+                    </div>
+                    <div>
+                        <p className='flex items-center gap-2 mb-2 text-sm text-gray-500'>
+                            <FaRegCalendarAlt />
+                            <span>{formatDate(props.createdAt)}</span>
+                        </p>
+                        <h2 className='text-2xl font-bold line-clamp-2'>
+                            {props.title}
+                        </h2>
+                    </div>
+                </CardContent>
+            </Card>
+        </Link>
+    )
+}
+
+export default BlogCard

--- a/frontend/src/components/ui/badge.jsx
+++ b/frontend/src/components/ui/badge.jsx
@@ -1,0 +1,47 @@
+import * as React from "react"
+import { cva } from "class-variance-authority";
+import { Slot } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "group/badge inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-4xl border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3!",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
+        secondary:
+          "bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80",
+        destructive:
+          "bg-destructive/10 text-destructive focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:focus-visible:ring-destructive/40 [a]:hover:bg-destructive/20",
+        outline:
+          "border-border text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground",
+        ghost:
+          "hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function Badge({
+  className,
+  variant = "default",
+  asChild = false,
+  ...props
+}) {
+  const Comp = asChild ? Slot.Root : "span"
+
+  return (
+    <Comp
+      data-slot="badge"
+      data-variant={variant}
+      className={cn(badgeVariants({ variant }), className)}
+      {...props} />
+  );
+}
+
+export { Badge, badgeVariants }

--- a/frontend/src/pages/Index.jsx
+++ b/frontend/src/pages/Index.jsx
@@ -1,8 +1,27 @@
+import BlogCard from '@/components/BlogCard'
+import Loading from '@/components/Loading'
+import { getEnv } from '@/helpers/getEnv'
+import { useFetch } from '@/hooks/useFetch'
 import React from 'react'
 
 const Index = () => {
+
+    const { data: blogData, loading, error } = useFetch(`${getEnv('VITE_BASE_API_URL')}/blogs/all`, {
+            method: 'GET',
+            credentials: 'include'
+    })
+
+    if (loading) return <Loading />
+
     return (
-        <div>Index</div>
+        <div className='grid grid-cols-3 gap-10'>
+            {blogData && blogData?.blogs?.length > 0
+                ?
+                blogData.blogs.map(blog => <BlogCard key={blog._id} props={blog} />)
+                :
+                <div>Datos no encontrados.</div>
+            }
+        </div>
     )
 }
 


### PR DESCRIPTION
Created BlogCard.jsx: reusable blog preview card (author avatar, featured image, title, date, admin badge).
Created badge.jsx: small UI badge component for role/status labels.
Updated Index.jsx: fetch /blogs/all and render BlogCard previews on the homepage.
Updated blogs.service.ts: populate author with avatar and role to support avatar and admin badge display.
Updated file-upload.interceptor.ts: accept image/svg+xml and adjust error message.
Reason: Provide a visual blog preview on the homepage (author, image, date, title) and support SVG feature images and author metadata required by the new UI.