### PR TITLE
Single blog details: add backend APIs, include category slug, update …

### DIFF
--- a/backend/src/blogs/blogs.service.ts
+++ b/backend/src/blogs/blogs.service.ts
@@ -53,7 +53,7 @@ export class BlogsService {
             return await this.blogModel
                 .find()
                 .populate('author', 'name avatar role')
-                .populate('category', 'name')
+                .populate('category', 'name slug')
                 .sort({ createdAt: -1 })
                 .lean()
                 .exec();
@@ -68,7 +68,7 @@ export class BlogsService {
             const blog = await this.blogModel
                 .findById(blogId)
                 .populate('author', 'name avatar role')
-                .populate('category', 'name');
+                .populate('category', 'name slug');
             if (!blog) {
                 throw new NotFoundException('Datos no encontrados.');
             }

--- a/frontend/src/helpers/RouteName.js
+++ b/frontend/src/helpers/RouteName.js
@@ -20,10 +20,11 @@ export const RouteEditBlog = (blog_id) => {
         return `/blog/edit/:blog_id`
     }
 }
-export const RouteBlogDetails = (slug) => {
-    if (slug) {
-        return `/blog/details/${slug}`
-    } else {
-        return `/blog/details/:slug`
+export const RouteBlogDetails = (categorySlug, blogSlug) => {
+    if (categorySlug && blogSlug) {
+        return `/blog/details/${categorySlug}/${blogSlug}`
+    }
+    else {
+        return `/blog/details/:category/:slug` 
     }
 }

--- a/frontend/src/pages/SingleBlogDetails.jsx
+++ b/frontend/src/pages/SingleBlogDetails.jsx
@@ -1,4 +1,4 @@
-import { Avatar, AvatarImage } from '@/components/ui/avatar'
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import { getEnv } from '@/helpers/getEnv'
 import { useFetch } from '@/hooks/useFetch'
 import React from 'react'
@@ -8,8 +8,7 @@ import Loading from '@/components/Loading'
 
 const SingleBlogDetails = () => {
     const { category, slug } = useParams()
-    const { data, loading, error } = useFetch(
-        `${getEnv('VITE_BASE_API_URL')}/blogs/get-blog/${slug}`,
+    const { data, loading, error } = useFetch(`${getEnv('VITE_BASE_API_URL')}/blogs/get-blog/${slug}`,
         { method: 'GET', credentials: 'include' },
         [slug]
     )


### PR DESCRIPTION
…routes, add avatar fallback

Consolidates the prior "Initial addition of the blog detail page" with backend API additions and fixes:

Backend: add/confirm blog REST endpoints in blogs.controller.ts (POST /blogs/add, GET /blogs/all, GET /blogs/get-blog/:slug, GET /blogs/show/:blogId, PUT /blogs/update/:blogId, DELETE /blogs/delete/:blogId) and a reusable data parse/validate helper.
Backend: ensure category.slug is populated in blog queries so frontend can build full category+slug URLs (blogs.service.ts).
Frontend: use AvatarFallback and decode content on the details page (SingleBlogDetails.jsx).
Frontend: change RouteBlogDetails to accept (categorySlug, blogSlug) and produce /blog/details/:category/:slug (RouteName.js).
Notes: URL structure changed (old /blog/details/:slug → new /blog/details/:category/:slug) — update links/redirects as needed.