### PR TITLE
feat(blog-like): implement like/unlike feature (backend + frontend)

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -8,6 +8,7 @@ import { AuthModule } from './auth/auth.module';
 import { CategoryModule } from './categories/category.module';
 import { BlogsModule } from './blogs/blogs.module';
 import { CommentModule } from './comment/comment.module';
+import { BlogLikeModule } from './blog-like/blog-like.module';
 
 @Module({
   imports: [
@@ -39,6 +40,7 @@ import { CommentModule } from './comment/comment.module';
     CategoryModule,
     BlogsModule,
     CommentModule,
+    BlogLikeModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/blog-like/blog-like.controller.spec.ts
+++ b/backend/src/blog-like/blog-like.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BlogLikeController } from './blog-like.controller';
+
+describe('BlogLikeController', () => {
+  let controller: BlogLikeController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [BlogLikeController],
+    }).compile();
+
+    controller = module.get<BlogLikeController>(BlogLikeController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/backend/src/blog-like/blog-like.controller.ts
+++ b/backend/src/blog-like/blog-like.controller.ts
@@ -1,0 +1,31 @@
+import { Body, Controller, Get, HttpCode, HttpStatus, Param, Post } from '@nestjs/common';
+import { BlogLikeService } from './blog-like.service';
+import { DoLikeDto } from './dto/do-like.dto';
+
+@Controller('blog-like')
+export class BlogLikeController {
+    constructor(private readonly blogLikeService: BlogLikeService) { }
+
+    @Post('do-like')
+    @HttpCode(HttpStatus.OK)
+    async doLike(@Body() dto: DoLikeDto) {
+        return this.blogLikeService.doLike(dto);
+    }
+
+    @Get('get-like/:blogId/:userId')
+    @HttpCode(HttpStatus.OK)
+    async getLikeCountWithUser(
+        @Param('blogId') blogId: string,
+        @Param('userId') userId: string,
+    ) {
+        return this.blogLikeService.getLikeCount(blogId, userId);
+    }
+
+    @Get('get-like/:blogId')
+    @HttpCode(HttpStatus.OK)
+    async getLikeCount(
+        @Param('blogId') blogId: string,
+    ) {
+        return this.blogLikeService.getLikeCount(blogId);
+    }
+}

--- a/backend/src/blog-like/blog-like.module.ts
+++ b/backend/src/blog-like/blog-like.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { BlogLikeService } from './blog-like.service';
+import { BlogLikeController } from './blog-like.controller';
+import { MongooseModule } from '@nestjs/mongoose';
+import { BlogLike, BlogLikeSchema } from './schemas/blog-like.schema';
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([{ name: BlogLike.name, schema: BlogLikeSchema }]),
+  ],
+  providers: [BlogLikeService],
+  controllers: [BlogLikeController]
+})
+export class BlogLikeModule {}

--- a/backend/src/blog-like/blog-like.service.spec.ts
+++ b/backend/src/blog-like/blog-like.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BlogLikeService } from './blog-like.service';
+
+describe('BlogLikeService', () => {
+  let service: BlogLikeService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [BlogLikeService],
+    }).compile();
+
+    service = module.get<BlogLikeService>(BlogLikeService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/backend/src/blog-like/blog-like.service.ts
+++ b/backend/src/blog-like/blog-like.service.ts
@@ -1,0 +1,53 @@
+import { Injectable, InternalServerErrorException } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { BlogLike, BlogLikeDocument } from './schemas/blog-like.schema';
+import { Model } from 'mongoose';
+import { DoLikeDto } from './dto/do-like.dto';
+
+@Injectable()
+export class BlogLikeService {
+    constructor(
+        @InjectModel(BlogLike.name) private blogLikeModel: Model<BlogLikeDocument>,
+    ) { }
+
+    async doLike(dto: DoLikeDto): Promise<{ likeCount: number }> {
+        try {
+            const existing = await this.blogLikeModel.findOne({
+                user: dto.user,
+                blogId: dto.blogId,
+            });
+
+            if (!existing) {
+                await this.blogLikeModel.create(dto);
+            } else {
+                await this.blogLikeModel.findByIdAndDelete(existing._id);
+            }
+
+            const likeCount = await this.blogLikeModel.countDocuments({ blogId: dto.blogId });
+            return { likeCount };
+        } catch (error) {
+            const message = error instanceof Error ? error.message : 'Error interno del servidor';
+            throw new InternalServerErrorException(message);
+        }
+    }
+
+    async getLikeCount(
+        blogId: string,
+        userId?: string,
+    ): Promise<{ likeCount: number; isUserLiked: boolean }> {
+        try {
+            const likeCount = await this.blogLikeModel.countDocuments({ blogId });
+
+            let isUserLiked = false;
+            if (userId) {
+                const userLike = await this.blogLikeModel.countDocuments({ blogId, user: userId });
+                isUserLiked = userLike > 0;
+            }
+
+            return { likeCount, isUserLiked };
+        } catch (error) {
+            const message = error instanceof Error ? error.message : 'Error interno del servidor';
+            throw new InternalServerErrorException(message);
+        }
+    }
+}

--- a/backend/src/blog-like/dto/do-like.dto.ts
+++ b/backend/src/blog-like/dto/do-like.dto.ts
@@ -1,0 +1,11 @@
+import { IsMongoId, IsNotEmpty } from 'class-validator';
+
+export class DoLikeDto {
+    @IsNotEmpty({ message: 'El usuario es requerido.' })
+    @IsMongoId({ message: 'El usuario debe ser un ID válido.' })
+    user: string;
+
+    @IsNotEmpty({ message: 'El blog es requerido.' })
+    @IsMongoId({ message: 'El blog debe ser un ID válido.' })
+    blogId: string;
+}

--- a/backend/src/blog-like/schemas/blog-like.schema.ts
+++ b/backend/src/blog-like/schemas/blog-like.schema.ts
@@ -1,0 +1,15 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { HydratedDocument, Types } from 'mongoose';
+
+export type BlogLikeDocument = HydratedDocument<BlogLike>;
+
+@Schema({ timestamps: true, collection: 'bloglikes' })
+export class BlogLike {
+    @Prop({ type: Types.ObjectId, required: true, ref: 'User' })
+    user: Types.ObjectId;
+
+    @Prop({ type: Types.ObjectId, required: true, ref: 'Blog' })
+    blogId: Types.ObjectId;
+}
+
+export const BlogLikeSchema = SchemaFactory.createForClass(BlogLike);

--- a/frontend/src/components/LikeCount.jsx
+++ b/frontend/src/components/LikeCount.jsx
@@ -1,0 +1,67 @@
+import { getEnv } from '@/helpers/getEnv'
+import { showToast } from '@/helpers/showToast'
+import { useFetch } from '@/hooks/useFetch'
+import { useUserStore } from '@/store/useUserStore'
+import React, { useEffect, useState } from 'react'
+import { FaHeart } from 'react-icons/fa'
+
+const LikeCount = ({ props }) => {
+    const [likeCount, setLikeCount] = useState(0)
+    const [hasLiked, setHasLiked] = useState(false)
+
+    const isLogginIn = useUserStore((state) => state.isLogginIn)
+    const currentUser = useUserStore((state) => state.user)
+
+    const userId = isLogginIn ? currentUser._id : ''
+
+    const { data: blogLikeData } = useFetch(
+        `${getEnv('VITE_BASE_API_URL')}/blog-like/get-like/${props.blogId}/${userId}`,
+        { method: 'GET', credentials: 'include' },
+    )
+
+    useEffect(() => {
+        if (blogLikeData) {
+            setLikeCount(blogLikeData.likeCount)
+            setHasLiked(blogLikeData.isUserLiked)
+        }
+    }, [blogLikeData])
+
+    const handleLike = async () => {
+        if (!isLogginIn) {
+            return showToast('error', 'Debes iniciar sesión para dar me gusta.')
+        }
+
+        try {
+            const response = await fetch(`${getEnv('VITE_BASE_API_URL')}/blog-like/do-like`, {
+                method: 'POST',
+                credentials: 'include',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ user: currentUser._id, blogId: props.blogId }),
+            })
+
+            const responseData = await response.json()
+
+            if (!response.ok) {
+                return showToast('error', responseData.message || 'Error al dar me gusta.')
+            }
+
+            setLikeCount(responseData.likeCount)
+            setHasLiked(prev => !prev)
+        } catch (error) {
+            showToast('error', error.message || 'Error al dar me gusta.')
+        }
+    }
+
+    return (
+        <button
+            onClick={handleLike}
+            type='button'
+            className='flex justify-between items-center gap-1'
+        >
+            <FaHeart className={hasLiked ? 'text-red-500' : ''} />
+            <span>{likeCount}</span>
+        </button>
+    )
+}
+
+export default LikeCount

--- a/frontend/src/pages/SingleBlogDetails.jsx
+++ b/frontend/src/pages/SingleBlogDetails.jsx
@@ -6,9 +6,9 @@ import { useParams } from 'react-router-dom'
 import { decode } from 'entities'
 import Loading from '@/components/Loading'
 import Comment from '@/components/Comment'
-import CommentList from '@/components/CommentList'
 import CommentCount from '@/components/CommentCount'
 import moment from 'moment'
+import LikeCount from '@/components/LikeCount'
 
 const SingleBlogDetails = () => {
     const { category, slug } = useParams()
@@ -38,6 +38,7 @@ const SingleBlogDetails = () => {
                             </div>
                         </div>
                         <div className='flex items-center gap-5'>
+                            <LikeCount props={{ blogId: data.blog._id }} />
                             <CommentCount props={{ blogId: data.blog._id }} />
                         </div>
                     </div>


### PR DESCRIPTION
Add backend BlogLike module to support like/unlike behavior and counts. New files: blog-like.module.ts, blog-like.controller.ts, blog-like.service.ts, do-like.dto.ts, blog-like.schema.ts. Add unit tests: blog-like.controller.spec.ts, blog-like.service.spec.ts. Register module in app.module.ts.
Frontend: add LikeCount UI component and integrate into blog details. New file: LikeCount.jsx.
Integration: updated SingleBlogDetails.jsx to display/toggle likes. Behavior/API:
POST /blog-like/do-like — toggles like/unlike for a given user and blogId. GET /blog-like/get-like/:blogId — returns { likeCount, isUserLiked } (user optional). GET /blog-like/get-like/:blogId/:userId — returns count + whether the user has liked. Reason: Enable users to like/unlike blog posts, show live counts, and reflect whether the current user has liked a post.