### PR TITLE
feat(blogs): add related-blogs API and frontend RelatedBlog integration

### DIFF
--- a/backend/src/blogs/blogs.controller.ts
+++ b/backend/src/blogs/blogs.controller.ts
@@ -7,7 +7,8 @@ import { plainToClass } from 'class-transformer';
 import { UpdateBlogDto } from './dto/update-blog.dto';
 
 @Controller('blogs')
-export class BlogsController {constructor(private readonly blogService: BlogsService) { }
+export class BlogsController {
+        constructor(private readonly blogService: BlogsService) { }
 
     @Post('add')
     @HttpCode(HttpStatus.OK)
@@ -84,5 +85,15 @@ export class BlogsController {constructor(private readonly blogService: BlogsSer
             throw new BadRequestException(messages);
         }
         return dto;
+    }
+
+    @Get('get-related-blogs/:category/:blog')
+    @HttpCode(HttpStatus.OK)
+    async getRelatedBlogs(
+        @Param('category') category: string,
+        @Param('blog') blog: string,
+    ) {
+        const relatedBlog = await this.blogService.findRelated(category, blog);
+        return { success: true, relatedBlog };
     }
 }

--- a/backend/src/blogs/blogs.module.ts
+++ b/backend/src/blogs/blogs.module.ts
@@ -4,10 +4,14 @@ import { BlogsService } from './blogs.service';
 import { BlogsController } from './blogs.controller';
 import { Blog, BlogSchema } from './schemas/blog.schema';
 import { ConfigModule } from '@nestjs/config';
+import { Category, CategorySchema } from 'src/categories/schemas/category.schema';
 
 @Module({
   imports: [
-    MongooseModule.forFeature([{ name: Blog.name, schema: BlogSchema }]),
+    MongooseModule.forFeature([
+      { name: Blog.name, schema: BlogSchema },
+      { name: Category.name, schema: CategorySchema },
+    ]),
     ConfigModule,
   ],
   providers: [BlogsService],

--- a/backend/src/blogs/blogs.service.ts
+++ b/backend/src/blogs/blogs.service.ts
@@ -6,11 +6,13 @@ import { CreateBlogDto } from './dto/create-blog.dto';
 import { cloudinary } from '../config/cloudinary.config';
 import { encode } from 'entities';
 import { UpdateBlogDto } from './dto/update-blog.dto';
+import { Category, CategoryDocument } from 'src/categories/schemas/category.schema';
 
 @Injectable()
 export class BlogsService {
     constructor(
         @InjectModel(Blog.name) private blogModel: Model<BlogDocument>,
+        @InjectModel(Category.name) private categoryModel: Model<CategoryDocument>,
     ) { }
 
     async create(dto: CreateBlogDto, file?: Express.Multer.File): Promise<BlogDocument> {
@@ -136,6 +138,37 @@ export class BlogsService {
                 throw new NotFoundException('Datos no encontrados.');
             }
             return blog;
+        } catch (error) {
+            if (error instanceof NotFoundException) throw error;
+            const message = error instanceof Error ? error.message : 'Error interno del servidor';
+            throw new InternalServerErrorException(message);
+        }
+    }
+
+
+    async findRelated(categorySlug: string, currentSlug: string): Promise<BlogDocument[]> {
+        try {
+            const category = await this.categoryModel.findOne({ slug: categorySlug }).lean();
+            if (!category) {
+                throw new NotFoundException('Categoría no encontrada.');
+            }
+
+            const categoryId = category._id.toString();
+
+            return await this.blogModel
+                .find({
+                    $expr: {
+                        $and: [
+                            { $eq: [{ $toString: '$category' }, categoryId] },
+                            { $ne: ['$slug', currentSlug] },
+                        ],
+                    },
+                })
+                .sort({ createdAt: 1 })
+                .populate('author', 'name avatar role')
+                .populate('category', 'name slug')
+                .lean()
+                .exec();
         } catch (error) {
             if (error instanceof NotFoundException) throw error;
             const message = error instanceof Error ? error.message : 'Error interno del servidor';

--- a/frontend/src/components/RelatedBlog.jsx
+++ b/frontend/src/components/RelatedBlog.jsx
@@ -1,0 +1,41 @@
+import { getEnv } from '@/helpers/getEnv'
+import { useFetch } from '@/hooks/useFetch'
+import React from 'react'
+import { Link } from 'react-router-dom'
+import { RouteBlogDetails } from '@/helpers/RouteName'
+
+const RelatedBlog = ({ props }) => {
+    console.log('RelatedBlog props:', props)
+    const { data, loading } = useFetch(`${getEnv('VITE_BASE_API_URL')}/blogs/get-related-blogs/${props.category}/${props.currentBlog}`,
+        { method: 'GET', credentials: 'include' },
+        [props.category, props.currentBlog],
+    )
+    console.log('RelatedBlog data:', data)
+
+    if (loading || !props.category) return null
+
+    return (
+        <div>
+            <h2 className='text-2xl font-bold mb-5'>Blogs Relacionados</h2>
+            <div>
+                {data?.relatedBlog?.length > 0
+                    ? data.relatedBlog.map(blog => (
+                        <Link key={blog._id} to={RouteBlogDetails(props.category, blog.slug)}>
+                            <div className='flex items-center gap-2 mb-3'>
+                                <img
+                                    className='w-25 h-17.5 object-cover rounded-md'
+                                    src={blog.featuredImage}
+                                    alt={blog.title}
+                                />
+                                <h4 className='line-clamp-2 text-lg font-semibold'>{blog.title}</h4>
+                            </div>
+                        </Link>
+                    ))
+                    : <p className='text-gray-500 text-sm'>Sin blogs relacionados.</p>
+                }
+            </div>
+        </div>
+    )
+}
+
+export default RelatedBlog

--- a/frontend/src/pages/SingleBlogDetails.jsx
+++ b/frontend/src/pages/SingleBlogDetails.jsx
@@ -9,12 +9,13 @@ import Comment from '@/components/Comment'
 import CommentCount from '@/components/CommentCount'
 import moment from 'moment'
 import LikeCount from '@/components/LikeCount'
+import RelatedBlog from '@/components/RelatedBlog'
 
 const SingleBlogDetails = () => {
     const { category, slug } = useParams()
     const { data, loading } = useFetch(`${getEnv('VITE_BASE_API_URL')}/blogs/get-blog/${slug}`,
         { method: 'GET', credentials: 'include' },
-        [slug]
+        [slug, category],
     )
 
     if (loading) return <Loading />
@@ -22,36 +23,43 @@ const SingleBlogDetails = () => {
     return (
         <div className='flex justify-between gap-20'>
             {data?.blog && (
-                <div className='border rounded w-[70%] p-5'>
-                    <h1 className='text-2xl font-bold mb-5'>{data.blog.title}</h1>
-                    <div className='flex justify-between items-center'>
-                        <div className='flex items-center gap-5'>
-                            <Avatar>
-                                <AvatarImage src={data.blog.author?.avatar} alt={data.blog.author?.name} />
-                                <AvatarFallback>{data.blog.author?.name?.charAt(0)}</AvatarFallback>
-                            </Avatar>
-                            <div>
-                                <p className='font-bold'>{data.blog.author?.name}</p>
-                                <p className='text-xs text-gray-500'>
-                                    {moment(data.blog.createdAt).format('DD/MM/YYYY')}
-                                </p>
+                <>
+                    <div className='border rounded w-[70%] p-5'>
+                        <h1 className='text-2xl font-bold mb-5'>{data.blog.title}</h1>
+                        <div className='flex justify-between items-center'>
+                            <div className='flex items-center gap-5'>
+                                <Avatar>
+                                    <AvatarImage src={data.blog.author?.avatar} alt={data.blog.author?.name} />
+                                    <AvatarFallback>{data.blog.author?.name?.charAt(0)}</AvatarFallback>
+                                </Avatar>
+                                <div>
+                                    <p className='font-bold'>{data.blog.author?.name}</p>
+                                    <p className='text-xs text-gray-500'>
+                                        {moment(data.blog.createdAt).format('DD/MM/YYYY')}
+                                    </p>
+                                </div>
+                            </div>
+                            <div className='flex items-center gap-5'>
+                                <LikeCount props={{ blogId: data.blog._id }} />
+                                <CommentCount props={{ blogId: data.blog._id }} />
                             </div>
                         </div>
-                        <div className='flex items-center gap-5'>
-                            <LikeCount props={{ blogId: data.blog._id }} />
-                            <CommentCount props={{ blogId: data.blog._id }} />
+                        <div className='my-5'>
+                            <img src={data.blog.featuredImage} alt={data.blog.title} className='rounded' />
+                        </div>
+                        <div dangerouslySetInnerHTML={{ __html: decode(data.blog.blogContent || '') }} />
+                        <div className='border-t mt-5 pt-5'>
+                            <Comment props={{ blogId: data.blog._id }} />
                         </div>
                     </div>
-                    <div className='my-5'>
-                        <img src={data.blog.featuredImage} alt={data.blog.title} className='rounded' />
+                    <div className='border rounded w-[30%] p-5'>
+                        <RelatedBlog props={{
+                            category: data.blog.category?.slug ?? category,
+                            currentBlog: slug,
+                        }} />
                     </div>
-                    <div dangerouslySetInnerHTML={{ __html: decode(data.blog.blogContent || '') }} />
-                    <div className='border-t mt-5 pt-5'>
-                        <Comment props={{ blogId: data.blog._id }} />
-                    </div>
-                </div>
+                </>
             )}
-            <div className='border rounded w-[30%]' />
         </div>
     )
 }


### PR DESCRIPTION
Added backend endpoint to fetch related blogs and implemented service logic. Added/updated frontend component to fetch and display related posts on the single blog page. Files touched:

blogs.controller.ts
blogs.service.ts
RelatedBlog.jsx
SingleBlogDetails.jsx
Reason: expose a new API to retrieve blogs related to the current blog (by category, excluding the current slug) and show them in the frontend's single blog view.