### PR TITLE
Display blogs by category

### DIFF
--- a/backend/src/blogs/blogs.controller.ts
+++ b/backend/src/blogs/blogs.controller.ts
@@ -96,4 +96,11 @@ export class BlogsController {
         const relatedBlog = await this.blogService.findRelated(category, blog);
         return { success: true, relatedBlog };
     }
+
+    @Get('get-blog-by-category/:category')
+    @HttpCode(HttpStatus.OK)
+    async getBlogByCategory(@Param('category') category: string) {
+        const result = await this.blogService.findByCategory(category);
+        return { success: true, ...result };
+    }
 }

--- a/backend/src/blogs/blogs.service.ts
+++ b/backend/src/blogs/blogs.service.ts
@@ -175,4 +175,33 @@ export class BlogsService {
             throw new InternalServerErrorException(message);
         }
     }
+
+    async findByCategory(categorySlug: string): Promise<{ blogs: BlogDocument[]; categoryData: CategoryDocument }> {
+        try {
+            const categoryData = await this.categoryModel.findOne({ slug: categorySlug }).lean();
+            if (!categoryData) {
+                throw new NotFoundException('Datos de la categoría no encontrados.');
+            }
+
+            const categoryId = categoryData._id.toString();
+
+            const blogs = await this.blogModel
+                .find({
+                    $expr: {
+                        $eq: [{ $toString: '$category' }, categoryId],
+                    },
+                })
+                .populate('author', 'name avatar role')
+                .populate('category', 'name slug')
+                .sort({ createdAt: -1 })
+                .lean()
+                .exec();
+
+            return { blogs, categoryData };
+        } catch (error) {
+            if (error instanceof NotFoundException) throw error;
+            const message = error instanceof Error ? error.message : 'Error interno del servidor';
+            throw new InternalServerErrorException(message);
+        }
+    }
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { BrowserRouter, Route, Routes } from 'react-router-dom'
 import Layout from './layout/Layout'
-import { RouteAddBlog, RouteAddCategory, RouteBlog, RouteBlogDetails, RouteCategoryDetails, RouteEditBlog, RouteEditCategory, RouteIndex, RouteProfile, RouteSignIn, RouteSignUp } from './helpers/RouteName'
+import { RouteAddBlog, RouteAddCategory, RouteBlog, RouteBlogByCategory, RouteBlogDetails, RouteCategoryDetails, RouteEditBlog, RouteEditCategory, RouteIndex, RouteProfile, RouteSignIn, RouteSignUp } from './helpers/RouteName'
 import Index from './pages/Index'
 import SignIn from './pages/Signin'
 import SignUp from './pages/SignUp'
@@ -13,6 +13,7 @@ import AddBlog from './pages/blog/AddBlog'
 import EditBlog from './pages/blog/EditBlog'
 import BlogDetails from './pages/blog/BlogDetails'
 import SingleBlogDetails from './pages/SingleBlogDetails'
+import BlogByCategory from './pages/blog/BlogByCategory'
 
 const App = () => {
   return (
@@ -29,6 +30,7 @@ const App = () => {
             {/** Blogs */}
             <Route path={RouteAddBlog} element={<AddBlog />} />
             <Route path={RouteBlogDetails()} element={<SingleBlogDetails />} />
+            <Route path={RouteBlogByCategory()} element={<BlogByCategory />} />
             <Route path={RouteBlog} element={<BlogDetails />} />
             <Route path={RouteEditBlog()} element={<EditBlog />} />
           </Route>

--- a/frontend/src/components/AppSidebar.jsx
+++ b/frontend/src/components/AppSidebar.jsx
@@ -16,7 +16,7 @@ import { IoHomeOutline } from 'react-icons/io5'
 import { BiCategoryAlt } from 'react-icons/bi'
 import { FaBlog, FaRegComment } from 'react-icons/fa6'
 import { LuUsers } from 'react-icons/lu'
-import { RouteBlog, RouteCategoryDetails } from '@/helpers/RouteName'
+import { RouteBlog, RouteBlogByCategory, RouteCategoryDetails } from '@/helpers/RouteName'
 import { useFetch } from '@/hooks/useFetch'
 import { getEnv } from '@/helpers/getEnv'
 import { resolveIcon } from '@/helpers/resolveIcon'
@@ -93,7 +93,7 @@ const AppSidebar = () => {
                     <SidebarMenu>
                         {sortedCategories.length > 0 && sortedCategories.map(category => <SidebarMenuItem key={category.id}>
                             <SidebarMenuButton asChild>
-                                <Link to="">
+                                <Link to={RouteBlogByCategory(category.slug)}>
                                     {resolveIcon(category.icon)}
                                     <span>{category.name}</span>
                                 </Link>

--- a/frontend/src/helpers/RouteName.js
+++ b/frontend/src/helpers/RouteName.js
@@ -28,3 +28,10 @@ export const RouteBlogDetails = (categorySlug, blogSlug) => {
         return `/blog/details/:category/:slug` 
     }
 }
+export const RouteBlogByCategory = (category) => {
+    if (category) {
+        return `/blog/${category}`
+    } else {
+        return `/blog/:category`
+    }
+}

--- a/frontend/src/pages/blog/BlogByCategory.jsx
+++ b/frontend/src/pages/blog/BlogByCategory.jsx
@@ -1,0 +1,36 @@
+import BlogCard from '@/components/BlogCard'
+import Loading from '@/components/Loading'
+import { getEnv } from '@/helpers/getEnv'
+import { resolveIcon } from '@/helpers/resolveIcon'
+import { useFetch } from '@/hooks/useFetch'
+import React from 'react'
+import { useParams } from 'react-router-dom'
+
+const BlogByCategory = () => {
+    const { category } = useParams()
+    const { data: blogData, loading } = useFetch(`${getEnv('VITE_BASE_API_URL')}/blogs/get-blog-by-category/${category}`,
+        { method: 'GET', credentials: 'include' },
+        [category]
+    )
+
+    if (loading) return <Loading />
+
+    return (
+        <>
+            <div className='flex items-center gap-3 text-2xl font-bold text-violet-700 border-b pb-3 mb-5'>
+                {resolveIcon(blogData?.categoryData?.icon, { size: 28 })}
+                <h4>{blogData?.categoryData?.name}</h4>
+            </div>
+            <div className='grid grid-cols-3 gap-10'>
+                {blogData?.blogs?.length > 0
+                    ?
+                    blogData.blogs.map(blog => <BlogCard key={blog._id} props={blog} />)
+                    : 
+                    <div className='col-span-3'>Datos no encontrados.</div>
+                }
+            </div>
+        </>
+    )
+}
+
+export default BlogByCategory


### PR DESCRIPTION
Add a dedicated category page and wire frontend + backend to list blogs filtered by their category.

Added:
- frontend/src/pages/blog/BlogByCategory.jsx

Modified:
- backend/src/blogs/blogs.controller.ts
- backend/src/blogs/blogs.service.ts
- frontend/src/App.jsx
- frontend/src/components/AppSidebar.jsx
- frontend/src/helpers/RouteName.js

Why:
Enable users to view posts scoped to a selected category; backend now provides filtered results and frontend routes/components render them.