### PR TITLE
Add NotFound page and router fallback

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -19,6 +19,7 @@ import Comments from './pages/Comments'
 import User from './pages/User'
 import AuthRouteProtection from './components/AuthRouteProtection'
 import OnlyAdminAllowed from './components/OnlyAdminAllowed'
+import NotFound from './components/NotFound'
 
 const App = () => {
   return (
@@ -43,6 +44,7 @@ const App = () => {
               <Route path={RouteAddCategory} element={<AddCategory />} />
               <Route path={RouteEditCategory()} element={<EditCategory />} />
             </Route>
+            <Route path='*' element={<NotFound />} /> 
           </Route>
           <Route path={RouteSignIn} element={<SignIn />} />
           <Route path={RouteSignUp} element={<SignUp />} />

--- a/frontend/src/components/NotFound.jsx
+++ b/frontend/src/components/NotFound.jsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import { Link } from 'react-router-dom'
+import { RouteIndex } from '@/helpers/RouteName'
+import { TbError404 } from 'react-icons/tb'
+
+const NotFound = () => {
+    return (
+        <div className='flex flex-col items-center justify-center min-h-[60vh] gap-6 text-center'>
+            <TbError404 size={100} className='text-violet-400 dark:text-violet-500' />
+            <div className='flex flex-col gap-2'>
+                <h1 className='text-3xl font-bold dark:text-slate-100'>
+                    Página no encontrada
+                </h1>
+                <p className='text-gray-500 dark:text-slate-400 max-w-sm'>
+                    La URL que ingresaste no corresponde a ninguna página existente.
+                    Puede que tenga un error de escritura.
+                </p>
+            </div>
+            <Link
+                to={RouteIndex}
+                className='bg-violet-500 hover:bg-violet-600 text-white font-medium px-6 py-2 rounded-full transition-colors'
+            >
+                Volver al inicio
+            </Link>
+        </div>
+    )
+}
+
+export default NotFound

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.jsx'
 import { ToastContainer } from 'react-toastify'
+import 'react-toastify/dist/ReactToastify.css'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
 const queryClient = new QueryClient()
@@ -10,7 +11,17 @@ const queryClient = new QueryClient()
 createRoot(document.getElementById('root')).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
-      <ToastContainer />
+      <ToastContainer
+        position="top-right"
+        autoClose={3500}
+        hideProgressBar={false}
+        closeOnClick
+        pauseOnHover
+        pauseOnFocusLoss={false}
+        draggable
+        theme="colored"
+        limit={4}
+      />
       <App />
     </QueryClientProvider>
   </StrictMode>

--- a/frontend/src/pages/SingleBlogDetails.jsx
+++ b/frontend/src/pages/SingleBlogDetails.jsx
@@ -13,17 +13,19 @@ import RelatedBlog from '@/components/RelatedBlog'
 import { useUserStore } from '@/store/useUserStore'
 import { RouteEditBlog } from '@/helpers/RouteName'
 import { FiEdit } from 'react-icons/fi'
+import NotFound from '@/components/NotFound'
 
 const SingleBlogDetails = () => {
     const { category, slug } = useParams()
     const currentUser = useUserStore((state) => state.user)
 
-    const { data, loading } = useFetch(`${getEnv('VITE_BASE_API_URL')}/blogs/get-blog/${slug}`,
+    const { data, loading, error } = useFetch(`${getEnv('VITE_BASE_API_URL')}/blogs/get-blog/${slug}`,
         { method: 'GET', credentials: 'include' },
         [slug, category],
     )
 
     if (loading) return <Loading />
+    if (error || !data?.blog) return <NotFound />
 
     const isAuthor = currentUser?._id && data?.blog?.author?._id === currentUser._id
 


### PR DESCRIPTION
Summary: Add a friendly NotFound (404) UI and register a router fallback to handle unknown or broken frontend routes.
Why: Improve UX by showing a clear 404 page when a route or resource is missing (e.g., a broken link or a missing blog).
Changes: Render NotFound for unknown paths; update SingleBlogDetails to show NotFound when a blog is not found.
Files: NotFound.jsx, App.jsx, SingleBlogDetails.jsx.